### PR TITLE
fix(linux): remove org.mozilla reference in DBus names

### DIFF
--- a/src/toolkit/components/remote/nsDBusRemoteClient.patch
+++ b/src/toolkit/components/remote/nsDBusRemoteClient.patch
@@ -1,0 +1,90 @@
+diff --git a/toolkit/components/remote/nsDBusRemoteClient.cpp b/toolkit/components/remote/nsDBusRemoteClient.cpp
+index aad9d7054af8..a926d8b6abdc 100644
+--- a/toolkit/components/remote/nsDBusRemoteClient.cpp
++++ b/toolkit/components/remote/nsDBusRemoteClient.cpp
+@@ -76,7 +76,7 @@ bool nsDBusRemoteClient::GetRemoteDestinationName(const char* aProgram,
+   mozilla::XREAppData::SanitizeNameForDBus(profileName);
+ 
+   aDestinationName =
+-      nsPrintfCString("org.mozilla.%s.%s", aProgram, profileName.get());
++      nsPrintfCString("app.glide_browser.%s.%s", aProgram, profileName.get());
+   if (aDestinationName.Length() > DBUS_MAXIMUM_NAME_LENGTH)
+     aDestinationName.Truncate(DBUS_MAXIMUM_NAME_LENGTH);
+ 
+@@ -90,7 +90,7 @@ bool nsDBusRemoteClient::GetRemoteDestinationName(const char* aProgram,
+   if (!sDBusValidateBusName(aDestinationName.get(), nullptr)) {
+     // We don't have a valid busName yet - try to create a default one.
+     aDestinationName =
+-        nsPrintfCString("org.mozilla.%s.%s", aProgram, "default");
++        nsPrintfCString("app.glide_browser.%s.%s", aProgram, "default");
+     if (!sDBusValidateBusName(aDestinationName.get(), nullptr)) {
+       // We failed completelly to get a valid bus name - just quit
+       // to prevent crash at dbus_bus_request_name().
+@@ -117,7 +117,7 @@ nsresult nsDBusRemoteClient::DoSendDBusCommandLine(const char* aProfile,
+   }
+ 
+   nsAutoCString pathName;
+-  pathName = nsPrintfCString("/org/mozilla/%s/Remote", appName.get());
++  pathName = nsPrintfCString("/app/glide_browser/%s/Remote", appName.get());
+ 
+   static auto sDBusValidatePathName = (bool (*)(const char*, DBusError*))dlsym(
+       RTLD_DEFAULT, "dbus_validate_path");
+@@ -128,7 +128,7 @@ nsresult nsDBusRemoteClient::DoSendDBusCommandLine(const char* aProfile,
+   }
+ 
+   nsAutoCString remoteInterfaceName;
+-  remoteInterfaceName = nsPrintfCString("org.mozilla.%s", appName.get());
++  remoteInterfaceName = nsPrintfCString("app.glide_browser.%s", appName.get());
+ 
+   LOG("  DBus destination: %s\n", destinationName.get());
+   LOG("  DBus path: %s\n", pathName.get());
+diff --git a/toolkit/components/remote/nsDBusRemoteServer.cpp b/toolkit/components/remote/nsDBusRemoteServer.cpp
+index 4afb8381d0bc..bd927334b817 100644
+--- a/toolkit/components/remote/nsDBusRemoteServer.cpp
++++ b/toolkit/components/remote/nsDBusRemoteServer.cpp
+@@ -29,7 +29,7 @@ static const char* introspect_template =
+     "1.0//EN\"\n"
+     "\"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
+     "<node>\n"
+-    " <interface name=\"org.mozilla.%s\">\n"
++    " <interface name=\"app.glide_browser.%s\">\n"
+     "   <method name=\"OpenURL\">\n"
+     "     <arg name=\"url\" direction=\"in\" type=\"ay\"/>\n"
+     "   </method>\n"
+@@ -39,7 +39,7 @@ static const char* introspect_template =
+ bool nsDBusRemoteServer::HandleOpenURL(const gchar* aInterfaceName,
+                                        const gchar* aMethodName,
+                                        Span<const gchar> aParam) {
+-  nsPrintfCString ourInterfaceName("org.mozilla.%s", mAppName.get());
++  nsPrintfCString ourInterfaceName("app.glide_browser.%s", mAppName.get());
+ 
+   if ((strcmp("OpenURL", aMethodName) != 0) ||
+       (strcmp(ourInterfaceName.get(), aInterfaceName) != 0)) {
+@@ -132,7 +132,7 @@ static const GDBusInterfaceVTable gInterfaceVTable = {
+     HandleMethodCall, HandleGetProperty, HandleSetProperty};
+ 
+ void nsDBusRemoteServer::OnBusAcquired(GDBusConnection* aConnection) {
+-  mPathName = nsPrintfCString("/org/mozilla/%s/Remote", mAppName.get());
++  mPathName = nsPrintfCString("/app/glide_browser/%s/Remote", mAppName.get());
+   static auto sDBusValidatePathName = (bool (*)(const char*, DBusError*))dlsym(
+       RTLD_DEFAULT, "dbus_validate_path");
+   if (!sDBusValidatePathName ||
+@@ -206,8 +206,7 @@ nsresult nsDBusRemoteServer::Startup(const char* aAppName,
+ 
+   mozilla::XREAppData::SanitizeNameForDBus(profileName);
+ 
+-  nsPrintfCString busName("org.mozilla.%s.%s", mAppName.get(),
+-                          profileName.get());
++  nsPrintfCString busName("app.glide_browser.%s.%s", mAppName.get(), profileName.get());
+   if (busName.Length() > DBUS_MAXIMUM_NAME_LENGTH) {
+     busName.Truncate(DBUS_MAXIMUM_NAME_LENGTH);
+   }
+@@ -221,7 +220,7 @@ nsresult nsDBusRemoteServer::Startup(const char* aAppName,
+ 
+   // We don't have a valid busName yet - try to create a default one.
+   if (!sDBusValidateBusName(busName.get(), nullptr)) {
+-    busName = nsPrintfCString("org.mozilla.%s.%s", mAppName.get(), "default");
++    busName = nsPrintfCString("app.glide_browser.%s.%s", mAppName.get(), "default");
+     if (!sDBusValidateBusName(busName.get(), nullptr)) {
+       // We failed completelly to get a valid bus name - just quit
+       // to prevent crash at dbus_bus_request_name().


### PR DESCRIPTION
Changes the DBus prefix from `org.mozilla.` to `app.glide_browser.`