### PR TITLE
feat: enable JPEG XL support

### DIFF
--- a/src/toolkit/moz-configure.patch
+++ b/src/toolkit/moz-configure.patch
@@ -1,8 +1,8 @@
 diff --git a/toolkit/moz.configure b/toolkit/moz.configure
-index 94843062f4bc77a400cfaf2c5faa9abea6c93f97..38cca1f34990ab8fb6df7a9416d4525c1ab3ac69 100644
+index 52bca068f90cd8e214900e8f3159e1f7e37fb3e8..776522e50f32d9fe805b8a2009f522129ee5b132 100644
 --- a/toolkit/moz.configure
 +++ b/toolkit/moz.configure
-@@ -87,6 +87,9 @@ option(
+@@ -86,6 +86,9 @@ option(
  )
  set_config("MOZ_INCLUDE_SOURCE_INFO", True, when="MOZ_INCLUDE_SOURCE_INFO")
  
@@ -12,7 +12,7 @@ index 94843062f4bc77a400cfaf2c5faa9abea6c93f97..38cca1f34990ab8fb6df7a9416d4525c
  option(
      "--with-distribution-id",
      nargs=1,
-@@ -931,9 +931,9 @@
+@@ -931,9 +934,9 @@ set_config("MOZ_SYSTEM_AV1", True, when="--with-system-av1")
  option("--disable-jxl", help="Disable jxl image support")
  
  


### PR DESCRIPTION
Glide's mozconfig specifies `--enable-jxl`, but this option only has an effect on Nightly builds.