### PR TITLE
feat(api): add glide.unstable.split_views for managing tab split views

### DIFF
--- a/@types/gecko.d.mts
+++ b/@types/gecko.d.mts
@@ -72,6 +72,10 @@ declare namespace GlobalBrowser {
 
     currentURI: nsIURI;
 
+    // split views
+    unsplitTabs(splitview: any): void;
+    addTabSplitView(tabs: BrowserTab[], opts?: { id?: string }): { splitViewId: string; tabs: BrowserTab[] } | null;
+
     // notifications
     getNotificationBox(): NotificationBox;
 
@@ -86,6 +90,7 @@ declare namespace GlobalBrowser {
   interface TabContainer {
     allTabs: BrowserTab[];
     selectedIndex: number;
+    querySelector(selectors: string): HTMLElement | null;
   }
 
   /** Corresponds to the `<browser>` element */

--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -683,6 +683,39 @@ declare global {
 
     unstable: {
       /**
+       * Manage tab split views.
+       *
+       * **note**: split views are experimental in Firefox, there *will* be bugs.
+       */
+      split_views: {
+        /**
+         * Start a split view with the given tabs.
+         *
+         * At least 2 tabs must be passed.
+         *
+         * **note**: this will not work if one of the given tabs is *pinned*.
+         */
+        create(tabs: Array<TabID | Browser.Tabs.Tab>, opts?: glide.SplitViewCreateOpts): glide.SplitView;
+
+        /**
+         * Given a tab, tab ID, or a splitview ID, return the corresponding split view.
+         */
+        get(tab: SplitViewID | TabID | Browser.Tabs.Tab): glide.SplitView | null;
+
+        /**
+         * Revert a tab in a split view to a normal tab.
+         *
+         * If the given tab is *not* in a split view, then an error is thrown.
+         */
+        separate(tab: SplitViewID | TabID | Browser.Tabs.Tab): void;
+
+        /**
+         * Whether or not the given tab is in a split view.
+         */
+        has_split_view(tab: TabID | Browser.Tabs.Tab): boolean;
+      };
+
+      /**
        * Include another file as part of your config. The given file is evluated as if it
        * was just another Glide config file.
        *
@@ -1204,6 +1237,15 @@ declare global {
 
     export type HintLocation = "content" | "browser-ui";
 
+    export type SplitViewCreateOpts = {
+      id?: string;
+    };
+
+    export type SplitView = {
+      id: string;
+      tabs: Browser.Tabs.Tab[];
+    };
+
     export type KeyNotation = {
       /**
        * @example <leader>
@@ -1395,6 +1437,9 @@ declare global {
       size: number | undefined;
     };
   }
+
+  type TabID = number;
+  type SplitViewID = string;
 
   /**
    * Dedent template function.

--- a/src/glide/browser/base/content/test/split-views/browser.toml
+++ b/src/glide/browser/base/content/test/split-views/browser.toml
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+
+["dist/browser_split_views.js"]
+https_first_disabled = true

--- a/src/glide/browser/base/content/test/split-views/browser_split_views.ts
+++ b/src/glide/browser/base/content/test/split-views/browser_split_views.ts
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/* Any copyright is dedicated to the Public Domain.
+ * https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const TEST_URI_1 = "http://mochi.test:8888/browser/glide/browser/base/content/test/mode/input_test.html";
+const TEST_URI_2 = "http://example.com/";
+
+add_task(async function test_split_views() {
+  await GlideTestUtils.reload_config(function _() {
+    glide.keymaps.set("normal", "~", async () => {
+      const tabs = (await glide.tabs.query({})) as Tuple<Browser.Tabs.Tab, 4>;
+
+      glide.g.value = glide.unstable.split_views.create([tabs[1], tabs[2]]);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      assert(glide.unstable.split_views.has_split_view(tabs[1]));
+      assert(glide.unstable.split_views.has_split_view(tabs[2]));
+      assert(!glide.unstable.split_views.has_split_view(tabs[3]));
+
+      for (const getter of [glide.g.value.id, tabs[1].id, tabs[1]]) {
+        const splitview = glide.unstable.split_views.get(getter);
+        assert(splitview, `split_views.get() should return for ${getter}`);
+        assert(splitview.id === glide.g.value.id);
+        assert(splitview.tabs.length === 2);
+        assert(splitview.tabs[0]!.id === tabs[1].id);
+        assert(splitview.tabs[1]!.id === tabs[2].id);
+      }
+
+      glide.unstable.split_views.separate(tabs[1]);
+
+      assert(!glide.unstable.split_views.has_split_view(tabs[1]));
+      assert(!glide.unstable.split_views.has_split_view(tabs[2]));
+      assert(!glide.unstable.split_views.has_split_view(tabs[3]));
+
+      glide.g.test_checked = true;
+    });
+  });
+
+  using _tab1 = await GlideTestUtils.new_tab(TEST_URI_1);
+  using _tab2 = await GlideTestUtils.new_tab(TEST_URI_2);
+  using _tab3 = await GlideTestUtils.new_tab(TEST_URI_2);
+
+  await keys("~");
+  await until(() => glide.g.test_checked, "Split view created successfully");
+
+  const splitview = glide.g.value as glide.SplitView;
+  is(typeof splitview.id, "string");
+  isjson(splitview.tabs.map((tab) => tab.id), [3, 4]);
+  isjson(splitview.tabs.map((tab) => tab.url), [TEST_URI_1, TEST_URI_2]);
+});
+
+add_task(async function test_create_split_view_tab_ids() {
+  await GlideTestUtils.reload_config(function _() {
+    glide.keymaps.set("normal", "~", async () => {
+      const tabs = (await glide.tabs.query({})) as Tuple<Browser.Tabs.Tab, 4>;
+
+      glide.unstable.split_views.create([tabs[1].id!, tabs[2].id!]);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      assert(glide.unstable.split_views.has_split_view(tabs[1]));
+      assert(glide.unstable.split_views.has_split_view(tabs[2]));
+      assert(!glide.unstable.split_views.has_split_view(tabs[3]));
+
+      glide.g.test_checked = true;
+    });
+  });
+
+  using _tab1 = await GlideTestUtils.new_tab(TEST_URI_1);
+  using _tab2 = await GlideTestUtils.new_tab(TEST_URI_2);
+  using _tab3 = await GlideTestUtils.new_tab(TEST_URI_2);
+
+  await keys("~");
+  await until(() => glide.g.test_checked, "Split view created successfully with tab IDs");
+});
+
+add_task(async function test_create_split_view_custom_id() {
+  await GlideTestUtils.reload_config(function _() {
+    glide.keymaps.set("normal", "~", async () => {
+      const tabs = (await glide.tabs.query({})) as Tuple<Browser.Tabs.Tab, 4>;
+
+      const splitview_tabs = [tabs[1].id!, tabs[2].id!];
+      const splitview = glide.unstable.split_views.create(splitview_tabs, { id: "my-splitview" });
+      assert(splitview.id === "my-splitview");
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      assert(glide.unstable.split_views.get("my-splitview"));
+
+      try {
+        glide.unstable.split_views.create(splitview_tabs, { id: "my-splitview" });
+      } catch (err) {
+        glide.g.value = err;
+      }
+
+      glide.unstable.split_views.separate(splitview.id);
+      glide.g.test_checked = true;
+    });
+  });
+
+  using _tab1 = await GlideTestUtils.new_tab(TEST_URI_1);
+  using _tab2 = await GlideTestUtils.new_tab(TEST_URI_2);
+  using _tab3 = await GlideTestUtils.new_tab(TEST_URI_2);
+
+  await keys("~");
+  await until(() => glide.g.test_checked, "Split view created with custom ID");
+
+  is(String(glide.g.value), "Error: Could not create a splitview; The 'my-splitview' ID is already in use");
+});
+
+add_task(async function test_create_split_view_with_pinned_tab() {
+  await GlideTestUtils.reload_config(function _() {
+    glide.keymaps.set("normal", "~", async () => {
+      const tabs = (await glide.tabs.query({})) as Tuple<Browser.Tabs.Tab, 4>;
+
+      await browser.tabs.update(tabs[1].id, { pinned: true });
+
+      try {
+        glide.unstable.split_views.create([tabs[1].id!, tabs[2].id!]);
+      } catch (err) {
+        glide.g.value = err;
+      }
+
+      glide.g.test_checked = true;
+    });
+  });
+
+  using _tab1 = await GlideTestUtils.new_tab(TEST_URI_1);
+  using _tab2 = await GlideTestUtils.new_tab(TEST_URI_2);
+  using _tab3 = await GlideTestUtils.new_tab(TEST_URI_2);
+
+  await keys("~");
+  await until(() => glide.g.test_checked, "Test to finish");
+
+  is(String(glide.g.value), "Error: Could not create a splitview; Is one of the tabs pinned?");
+});

--- a/src/glide/browser/base/moz.build
+++ b/src/glide/browser/base/moz.build
@@ -22,6 +22,7 @@ BROWSER_CHROME_MANIFESTS += [
     "content/test/navigation/browser.toml",
     "content/test/process/browser.toml",
     "content/test/scrolling/browser.toml",
+    "content/test/split-views/browser.toml",
     "content/test/tutor/browser.toml",
     "content/test/utils/browser.toml",
 ]

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -101,6 +101,11 @@ text-decoration: none;
 [`glide.keys.next_str()`](#glide.keys.next_str)\
 [`glide.keys.parse()`](#glide.keys.parse)\
 [`glide.unstable`](#glide.unstable)\
+[`glide.unstable.split_views`](#glide.unstable.split_views)\
+[`glide.unstable.split_views.create()`](#glide.unstable.split_views.create)\
+[`glide.unstable.split_views.get()`](#glide.unstable.split_views.get)\
+[`glide.unstable.split_views.separate()`](#glide.unstable.split_views.separate)\
+[`glide.unstable.split_views.has_split_view()`](#glide.unstable.split_views.has_split_view)\
 [`glide.unstable.include()`](#glide.unstable.include)\
 [`glide.path`](#glide.path)\
 [`glide.path.cwd`](#glide.path.cwd)\
@@ -131,6 +136,8 @@ text-decoration: none;
 [`glide.KeymapCallback`](#glide.KeymapCallback)\
 [`glide.KeymapCallbackProps`](#glide.KeymapCallbackProps)\
 [`glide.HintLocation`](#glide.HintLocation)\
+[`glide.SplitViewCreateOpts`](#glide.SplitViewCreateOpts)\
+[`glide.SplitView`](#glide.SplitView)\
 [`glide.KeyNotation`](#glide.KeyNotation)\
 [`glide.Keymap`](#glide.Keymap)\
 [`glide.KeymapOpts`](#glide.KeymapOpts)\
@@ -710,6 +717,42 @@ in in the input.
 
 ## • `glide.unstable` {% id="glide.unstable" %}
 
+### `glide.unstable.split_views` {% id="glide.unstable.split_views" %}
+
+Manage tab split views.
+
+**note**: split views are experimental in Firefox, there _will_ be bugs.
+
+{% api-heading id="glide.unstable.split_views.create" %}
+glide.unstable.split_views.create(tabs, opts?): glide.SplitView
+{% /api-heading %}
+
+Start a split view with the given tabs.
+
+At least 2 tabs must be passed.
+
+**note**: this will not work if one of the given tabs is _pinned_.
+
+{% api-heading id="glide.unstable.split_views.get" %}
+glide.unstable.split_views.get(tab): glide.SplitView | null
+{% /api-heading %}
+
+Given a tab, tab ID, or a splitview ID, return the corresponding split view.
+
+{% api-heading id="glide.unstable.split_views.separate" %}
+glide.unstable.split_views.separate(tab): void
+{% /api-heading %}
+
+Revert a tab in a split view to a normal tab.
+
+If the given tab is _not_ in a split view, then an error is thrown.
+
+{% api-heading id="glide.unstable.split_views.has_split_view" %}
+glide.unstable.split_views.has_split_view(tab): boolean
+{% /api-heading %}
+
+Whether or not the given tab is in a split view.
+
 {% api-heading id="glide.unstable.include" %}
 glide.unstable.include(path): Promise<void>
 {% /api-heading %}
@@ -1019,6 +1062,19 @@ tab_id: number;
 ```
 
 ## • `glide.HintLocation: "content" | "browser-ui"` {% id="glide.HintLocation" %}
+
+## • `glide.SplitViewCreateOpts` {% id="glide.SplitViewCreateOpts" %}
+
+```typescript {% highlight_prefix="type x = {" %}
+id?: string;
+```
+
+## • `glide.SplitView` {% id="glide.SplitView" %}
+
+```typescript {% highlight_prefix="type x = {" %}
+id: string;
+tabs: Browser.Tabs.Tab[];
+```
 
 ## • `glide.KeyNotation` {% id="glide.KeyNotation" %}
 


### PR DESCRIPTION
Example keymaps to create a new split view with the next tab:
```typescript
glide.keymaps.set("normal", "<C-w>v", async ({ tab_id }) => {
  const all_tabs = await glide.tabs.query({});
  const curr_index = all_tabs.findIndex((t) => t.id === tab_id);
  const other = all_tabs[curr_index + 1];
  if (!other) {
    throw new Error("no next tab");
  }
  glide.unstable.split_views.create([tab_id, other]);
});
glide.keymaps.set("normal", "<C-w>q", async ({ tab_id }) => {
  glide.unstable.split_views.separate(tab_id);
});
```