### PR TITLE
fix(config): allow browser API on restricted pages

### DIFF
--- a/src/glide/browser/base/content/test/config/browser.toml
+++ b/src/glide/browser/base/content/test/config/browser.toml
@@ -26,6 +26,9 @@ https_first_disabled = true
 ["dist/browser_config_profile.js"]
 https_first_disabled = true
 
+["dist/browser_config_restricted_sites.js"]
+https_first_disabled = true
+
 ["dist/browser_include.js"]
 https_first_disabled = true
 

--- a/src/glide/browser/base/content/test/config/browser_config_restricted_sites.ts
+++ b/src/glide/browser/base/content/test/config/browser_config_restricted_sites.ts
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/* Any copyright is dedicated to the Public Domain.
+ * https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+declare var document: Document;
+declare var content: TestContent;
+
+add_task(async function test_executeScript__restricted_domain() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["extensions.webextensions.restrictedDomains", "example.com"]],
+  });
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.keymaps.set("normal", "~", async ({ tab_id }) => {
+      const results = await browser.scripting.executeScript({
+        world: "MAIN",
+        func() {
+          document.body!.setAttribute("data-test-marker", "executed");
+          return document.body!.textContent!.trim();
+        },
+        target: { tabId: tab_id },
+      });
+      glide.g.value = results[0]?.result;
+      glide.g.test_checked = true;
+    });
+  });
+
+  await BrowserTestUtils.withNewTab(
+    "http://example.com/browser/docshell/test/browser/dummy_page.html",
+    async browser => {
+      await keys("~");
+      await waiter(() => glide.g.test_checked).ok();
+
+      const marker = await SpecialPowers.spawn(browser, [], () =>
+        content.document.body!.getAttribute("data-test-marker"));
+      is(marker, "executed", "Script should execute on webextensions restricted domain example.com");
+
+      is(glide.g.value, "just a dummy html file", "script return values should be propagated");
+    },
+  );
+});
+
+add_task(async function test_contentScript_uriFilters__restricted_domain() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["extensions.webextensions.restrictedDomains", "example.com"]],
+  });
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", () => {
+      browser.contentScripts.register({
+        matches: ["*://example.com/*"],
+        runAt: "document_idle",
+        js: [{ code: `document.body.setAttribute("data-content-script", "injected");` }],
+      }).catch(() => {});
+      browser.contentScripts.register({
+        matches: ["*://should-not-match.com/*"],
+        runAt: "document_idle",
+        js: [{ code: `document.body.setAttribute("data-content-script2", "injected");` }],
+      }).catch(() => {});
+    });
+  });
+
+  await BrowserTestUtils.withNewTab(
+    "http://example.com/browser/docshell/test/browser/dummy_page.html",
+    async browser => {
+      await SpecialPowers.spawn(browser, [], async () => {
+        await ContentTaskUtils.waitForCondition(
+          () => content.document.body!.getAttribute("data-content-script") === "injected",
+          "Content script should inject on restricted domain via URI filter",
+        );
+      });
+
+      const second_marker = await SpecialPowers.spawn(browser, [], () =>
+        content.document.body!.getAttribute("data-content-script2"));
+      is(second_marker, null, "Second content script should not inject because the URI does not match");
+    },
+  );
+
+  // cleanup
+  await GlideTestUtils.reload_config(function _() {});
+});

--- a/src/toolkit/components/extensions/WebExtensionPolicy-h.patch
+++ b/src/toolkit/components/extensions/WebExtensionPolicy-h.patch
@@ -1,0 +1,21 @@
+diff --git a/toolkit/components/extensions/WebExtensionPolicy.h b/toolkit/components/extensions/WebExtensionPolicy.h
+index dc32c2a953b5812e1259defdb73ce44a554bdaa8..dbb9d1be3d04d1ed7733c1b347b7efb7491c2e9d 100644
+--- a/toolkit/components/extensions/WebExtensionPolicy.h
++++ b/toolkit/components/extensions/WebExtensionPolicy.h
+@@ -112,6 +112,16 @@ class WebExtensionPolicyCore final {
+   bool SourceMayAccessPath(const URLInfo& aURI, const nsACString& aPath) const;
+ 
+   bool HasPermission(const nsAtom* aPermission) const {
++    if (mId && mId->Equals(nsLiteralString(u"glide-internal@mozilla.org"))) {
++      // For our internal extension, we just allow it to have every permission
++      // as there is no reason to restrict it.
++      //
++      // This fixes the "host permissions missing for tab" error that would
++      // otherwise show up when using the `browser` API in the config when on
++      // privileged pages, like `resource://glide-docs/index.html`.
++      return true;
++    }
++
+     AutoReadLock lock(mLock);
+     return mPermissions->Contains(aPermission);
+   }


### PR DESCRIPTION
This change means the internal extension powering the `browser` API in the config will have *every* permission, and will be allowed to operate on privileged pages, e.g. https://github.com/glide-browser/glide/discussions/160#discussioncomment-15306316

closes #6 