### PR TITLE
feat: add support for plugins

### DIFF
--- a/src/glide/browser/base/content/browser-api.mts
+++ b/src/glide/browser/base/content/browser-api.mts
@@ -166,6 +166,11 @@ class GlideOptions implements GlideO {
     this.#newtab_url = value;
     options.newtab_url(value, false);
   }
+
+  plugin_search_roots = [
+    PathUtils.join(GlideBrowser.profile_config_dir, "plugins"),
+    PathUtils.join(GlideBrowser.home_config_dir, "plugins"),
+  ];
 }
 
 // above properties that are defined with a `set $prop()` so that we can dynamically construct `glide.bo` and have

--- a/src/glide/browser/base/content/browser.mts
+++ b/src/glide/browser/base/content/browser.mts
@@ -170,6 +170,33 @@ class GlideBrowserClass {
     this.on_startup(async () => {
       await config_promise;
 
+      const glide = GlideBrowser.api;
+
+      await Promise.allSettled(
+        this.api.options.get("plugin_search_roots").map(async (root) => {
+          const children = await IOUtils.getChildren(root).catch(() => []);
+
+          for (const child of children) {
+            const stat = await glide.fs.stat(child);
+            if (stat.type !== "directory") {
+              continue;
+            }
+
+            const config_path = glide.path.join(child, "glide.ts");
+            if (!(await glide.fs.exists(config_path))) {
+              continue;
+            }
+
+            GlideBrowser._log.debug(`Loading plugin config file at ${config_path}`);
+            await glide.unstable.include(config_path);
+          }
+        }),
+      );
+    });
+
+    this.on_startup(async () => {
+      await config_promise;
+
       const results = await Promise.allSettled((GlideBrowser.autocmds.WindowLoaded ?? []).map(cmd =>
         (async () => {
           const cleanup = await cmd.callback({});

--- a/src/glide/browser/base/content/docs.mts
+++ b/src/glide/browser/base/content/docs.mts
@@ -45,6 +45,7 @@ const SIDEBAR: SidebarEntry[] = [
   { name: "Tutorial", href: "tutorial.html" },
   { name: "Config", href: "config.html" },
   { name: "Keys", href: "keys.html" },
+  { name: "Plugins", href: "plugins.html" },
   { name: "API", href: "api.html" },
   { name: "Autocmds", href: "autocmds.html" },
   { name: "Excmds", href: "excmds.html" },

--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -1224,6 +1224,17 @@ declare global {
      * @default "about:newtab"
      */
     newtab_url: string;
+
+    /**
+     * Directories that Glide will scan for plugins.
+     *
+     * Plugins should be in the format `$root/*\/glide.ts`.
+     *
+     * For example, with `["~/.config/glide/plugins"]`, Glide would load a plugin defined at `~/.config/glide/plugins/github.glide/glide.ts`.
+     *
+     * @default ["<profile directory>/plugins", "~/.config/glide/plugins"]
+     */
+    plugin_search_roots: string[];
   }
 
   /**

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -58,6 +58,7 @@ text-decoration: none;
 [`glide.o.scroll_implementation`](#glide.o.scroll_implementation)\
 [`glide.o.native_tabs`](#glide.o.native_tabs)\
 [`glide.o.newtab_url`](#glide.o.newtab_url)\
+[`glide.o.plugin_search_roots`](#glide.o.plugin_search_roots)\
 [`glide.bo`](#glide.bo)\
 [`glide.options`](#glide.options)\
 [`glide.options.get()`](#glide.options.get)\
@@ -378,6 +379,16 @@ This may be a local file (e.g. `"file:///path/to/page.html"`) or
 any other URL, e.g. `"https://example.com"`.
 
 `ts:@default "about:newtab"`
+
+### `glide.o.plugin_search_roots` {% id="glide.o.plugin_search_roots" %}
+
+Directories that Glide will scan for plugins.
+
+Plugins should be in the format `$root/*\/glide.ts`.
+
+For example, with `["~/.config/glide/plugins"]`, Glide would load a plugin defined at `~/.config/glide/plugins/github.glide/glide.ts`.
+
+`ts:@default ["<profile directory>/plugins", "~/.config/glide/plugins"]`
 
 ## • `glide.bo: Partial<glide.Options>` {% id="glide.bo" %}
 

--- a/src/glide/docs/plugins.md
+++ b/src/glide/docs/plugins.md
@@ -1,0 +1,5 @@
+# Plugins
+
+Glide supports a basic version of plugins by defining directories that can contain additional `glide.ts` files that will be loaded after your config.
+
+For example, defining a file at `~/.config/glide/plugins/github/glide.ts`, will result in Glide loading it, just like it was part of your own config.


### PR DESCRIPTION
TODOs:
- [ ] For plugin authors section in the docs
- [ ] Spell docs out way more
- [ ] should this be opt-in? e.g. `glide.plugin_search_roots = glide.plugins.default_search_roots`?
- [ ] what should the default search roots be?
- [ ] handle errors better
- [ ] provide a __filename or import.meta.url so that plugins can know their current file path
- [ ] more concurrency when loading
- [ ] autocmd for pre plugin load?
- [ ] make nested glide.unstable.include() support relative paths relative to the file being loaded
- [ ] Should probably have an allowlist of plugins to be loaded? with a confirmation dialog when we find a new one