### PR TITLE
feat(api/hints): support generating labels from content element data

### DIFF
--- a/@types/gecko.d.mts
+++ b/@types/gecko.d.mts
@@ -87,6 +87,7 @@ declare namespace GlobalBrowser {
     $hints_container?: HTMLElement | null | undefined;
     $hints_action?: glide.HintAction;
     $hints_pick?: glide.HintPicker;
+    $hints_label_generator?: glide.HintLabelGenerator;
     $hints_location?: glide.HintLocation;
     // TODO(glide): just look at the elements in the container instead?
     $hints?: GlideResolvedHint[];

--- a/src/glide/browser/base/content/browser-api.mts
+++ b/src/glide/browser/base/content/browser-api.mts
@@ -308,6 +308,7 @@ export function make_glide_api(
 
         gBrowser.$hints_pick = opts?.pick;
         gBrowser.$hints_action = opts?.action;
+        gBrowser.$hints_label_generator = opts?.label_generator;
 
         actor.send_async_message("Glide::Hint", {
           action: typeof opts?.action !== "function" ? opts?.action : undefined,

--- a/src/glide/browser/base/content/test/config/types/config.ts
+++ b/src/glide/browser/base/content/test/config/types/config.ts
@@ -168,4 +168,11 @@ glide.hints.show({
     assert_type<string>(await content.execute(() => "foo"));
     assert_type<string>(await content.execute((target) => target.id));
   },
+
+  async label_generator({ content }) {
+    assert_type<Promise<string[]>>(content.map(() => "foo"));
+    assert_type<string[]>(await content.map(() => "foo"));
+    assert_type<string[]>(await content.map((target) => target.id));
+    return [];
+  },
 });

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -146,6 +146,7 @@ text-decoration: none;
 [`glide.KeymapContentCallback`](#glide.KeymapContentCallback)\
 [`glide.KeymapCallbackProps`](#glide.KeymapCallbackProps)\
 [`glide.HintLabelGenerator`](#glide.HintLabelGenerator)\
+[`glide.HintLabelGeneratorProps`](#glide.HintLabelGeneratorProps)\
 [`glide.HintPicker`](#glide.HintPicker)\
 [`glide.HintPickerProps`](#glide.HintPickerProps)\
 [`glide.HintLocation`](#glide.HintLocation)\
@@ -289,6 +290,24 @@ glide.o.hint_label_generator = ({ hints }) =>
     String(i)
   );
 ```
+
+Or using data from the hinted elements through `content.execute()`:
+
+```typescript
+glide.hints.show({
+  async label_generator({ content }) {
+    const texts = await content.execute((element) =>
+      element.textContent
+    );
+    return texts.map((text) =>
+      text.trim().toLowerCase().slice(0, 2)
+    );
+  },
+});
+```
+
+note: the above example is a very naive implementation and will result in issues if there are multiple
+elements that start with the same text.
 
 ### `glide.o.switch_mode_on_focus: boolean` {% id="glide.o.switch_mode_on_focus" %}
 
@@ -1182,10 +1201,26 @@ tab_id: number;
 ## • `glide.HintLabelGenerator` {% id="glide.HintLabelGenerator" %}
 
 ```typescript {% highlight_prefix="type x = " %}
-(ctx: {
-    hints: glide.Hint[];
-}) => string[]
+(ctx: HintLabelGeneratorProps) => string[] | Promise<string[]>
 ```
+
+## • `glide.HintLabelGeneratorProps` {% id="glide.HintLabelGeneratorProps" %}
+
+````typescript {% highlight_prefix="type x = {" %}
+hints: glide.Hint[];
+content: {
+    /**
+     * Executes the given callback in the content process to extract properties
+     * from the all elements that are being hinted.
+     *
+     * For example:
+     * ```typescript
+     * const texts = await content.map((target) => target.textContent);
+     * ```
+     */
+    map<R>(cb: (target: HTMLElement, index: number) => R | Promise<R>): Promise<Awaited<R>[]>;
+};
+````
 
 ## • `glide.HintPicker` {% id="glide.HintPicker" %}
 


### PR DESCRIPTION
TODOs:
- [x] Rename `content.execute()` to make it more clear its a `.map()`?
- [x] check usage of `show_hints()` if it needs async handling
- [x] types test for the content fn