### PR TITLE
fix(types): allow <leader>-, <<, and < as valid keymap sequences

### DIFF
--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -1697,16 +1697,18 @@ declare global {
      *
      * `<C-` -> `<C-a>` | `<C-D-` ...
      * `<leader>` -> `<leader>f` | `<leader><CR>` ...
+     * `<leader>-` -> `<leader>-a` | `<leader>-<CR>` ...
      * `g` -> `gg` | `gj` ...
      */
     type T<LHS> = LHS extends "" ? SingleKey
-      : LHS extends "<" ? SpecialKey | `<${ModifierKey}-`
+      : LHS extends "<" ? LHS | SpecialKey | `<${ModifierKey}-`
       : LHS extends `${infer S}<${infer M}-` ?
+          | LHS
           | `${S}<${M}-${Exclude<StripAngles<SingleKey>, ModifierKey>}>`
           | `${S}<${M}-${ModifierKey}-`
-          | (S & {})
-      : LHS extends `${infer S}<` ? `${S}${SpecialKey}` | S
-      : LHS extends `${infer S}` ? `${S}${SingleKey}` | S
+      : LHS extends `${infer S}<` ? LHS | `${S}${SpecialKey}`
+      : LHS extends `${infer S}-` ? LHS | `${S}-${SingleKey}`
+      : LHS extends `${infer S}` ? LHS | `${S}${SingleKey}`
       : LHS;
 
     /**

--- a/src/glide/browser/base/content/test/config/types/config.ts
+++ b/src/glide/browser/base/content/test/config/types/config.ts
@@ -78,10 +78,12 @@ glide.keymaps.set("normal", "x", "help");
 glide.keymaps.set("normal", "p", "help");
 glide.keymaps.set("normal", "<C-space>", "help");
 glide.keymaps.set("normal", "<S-F5>", "help");
+glide.keymaps.set("normal", "<leader>-", "help");
+glide.keymaps.set("normal", "<<", "help");
+glide.keymaps.set("normal", "<", "help");
 
 // @ts-expect-error empty string
 glide.keymaps.set("normal", "", "help");
-// @ts-expect-error partially completed modifier
 glide.keymaps.set("normal", "<A-", "help");
 
 glide.autocmds.create("ConfigLoaded", () => {});


### PR DESCRIPTION
Fixes #140 

**Changes:**
- Include `LHS` in all conditional type branches to preserve the input literal allowing sequences like `<leader>-`, `<<`, and `<` to be accepted. 