### PR TITLE
refactor(api/hints)!: execute pick() in the main process

### DIFF
--- a/@types/gecko.d.mts
+++ b/@types/gecko.d.mts
@@ -86,6 +86,7 @@ declare namespace GlobalBrowser {
     /* used to cache the hint container element */
     $hints_container?: HTMLElement | null | undefined;
     $hints_action?: glide.HintAction;
+    $hints_pick?: glide.HintPicker;
     $hints_location?: glide.HintLocation;
     // TODO(glide): just look at the elements in the container instead?
     $hints?: GlideResolvedHint[];
@@ -185,8 +186,6 @@ declare type _ExtensionCommon =
 declare type GlideHintIPC = import("../src/glide/browser/base/content/hinting.mts").GlideHintIPC;
 
 declare type GlideResolvedHint = GlideHintIPC & {
-  x: number;
-  y: number;
   label: string;
 };
 

--- a/src/glide/browser/actors/GlideHandlerParent.sys.mts
+++ b/src/glide/browser/actors/GlideHandlerParent.sys.mts
@@ -58,7 +58,6 @@ export interface ParentMessages {
       | "newtab-click"
       | GlideFunctionIPC<(target: HTMLElement) => Promise<void>>
       | null;
-    pick?: GlideFunctionIPC<(hints: glide.ContentHint[]) => glide.ContentHint[]>;
   };
   "Glide::Move": { direction: "left" | "right" | "up" | "down" | "endline" };
   "Glide::Scroll": { to: "page_up" | "page_down" | "top" | "bottom" };
@@ -80,6 +79,12 @@ export interface ParentQueries {
       action: GlideFunctionIPC<(target: HTMLElement) => unknown | Promise<unknown>>;
     };
     result: unknown;
+  };
+  "Glide::Query::InvokeOnAllHints": {
+    props: {
+      callback: GlideFunctionIPC<(element: HTMLElement, index: number) => unknown | Promise<unknown>>;
+    };
+    result: unknown[];
   };
 }
 
@@ -197,10 +202,11 @@ export class GlideHandlerParent extends JSWindowActorParent<
           return;
         }
 
-        this.glide_hints!.show_hints(
+        await this.glide_hints!.show_hints(
           message.data.hints,
           message.data.location,
           this.gBrowser?.$hints_action ?? "click",
+          this.gBrowser?.$hints_pick,
           message.data.auto_activate,
         );
         break;

--- a/src/glide/browser/base/content/browser-api.mts
+++ b/src/glide/browser/base/content/browser-api.mts
@@ -306,6 +306,7 @@ export function make_glide_api(
           ? GlideBrowser.get_content_actor()
           : assert_never(location);
 
+        gBrowser.$hints_pick = opts?.pick;
         gBrowser.$hints_action = opts?.action;
 
         actor.send_async_message("Glide::Hint", {
@@ -316,7 +317,6 @@ export function make_glide_api(
           editable_only: opts?.editable ?? undefined,
           include_click_listeners: opts?.include_click_listeners,
           auto_activate: opts?.auto_activate ?? false,
-          pick: IPC.maybe_serialise_glidefunction(opts?.pick),
           browser_ui_rect: LayoutUtils.getElementBoundingScreenRect(document!.body),
           debug: Services.prefs.getBoolPref("devtools.testing", false),
         });

--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -564,10 +564,8 @@ declare global {
          *
          * An empty array may be returned but will result in an error notification indicating that no
          * hints were found.
-         *
-         * @content this function is evaluated in the content process.
          */
-        pick?: (hints: glide.ContentHint[]) => glide.ContentHint[];
+        pick?: glide.HintPicker;
       }): void;
 
       label_generators: {
@@ -1347,6 +1345,27 @@ declare global {
     export type ResolvedHint = glide.Hint & { label: string };
 
     export type HintLabelGenerator = (ctx: { hints: glide.Hint[] }) => string[];
+
+    export type HintPicker = (props: glide.HintPickerProps) => glide.Hint[] | Promise<glide.Hint[]>;
+
+    export type HintPickerProps = {
+      hints: glide.Hint[];
+
+      content: {
+        /**
+         * Executes the given callback in the content process to extract properties
+         * from the all elements that are being hinted.
+         *
+         * For example:
+         * ```typescript
+         * const areas = await content.map((element) => element.offsetWidth * element.offsetHeight);
+         * ```
+         */
+        map<R>(
+          cb: (target: HTMLElement, index: number) => R | Promise<R>,
+        ): Promise<Awaited<R>[]>;
+      };
+    };
 
     export type HintLocation = "content" | "browser-ui";
 

--- a/src/glide/browser/base/content/hinting.mts
+++ b/src/glide/browser/base/content/hinting.mts
@@ -178,17 +178,19 @@ function* all_elements(root: Document | ShadowRoot): Generator<HTMLElement> {
 }
 
 export const pickers = {
-  biggest_area: (hints) => {
+  biggest_area: async ({ hints, content }) => {
     if (!hints.length) {
       return [];
     }
 
+    const areas = await content.map((element) => element.offsetWidth * element.offsetHeight);
+
     let biggest_hint = hints[0]!;
-    let biggest_area = hints[0]!.element.offsetWidth * hints[0]!.element.offsetHeight;
+    let biggest_area = areas[0]!;
 
     for (let i = 1; i < hints.length; i++) {
       const hint = hints[i]!;
-      const area = hint.element.offsetWidth * hint.element.offsetHeight;
+      const area = areas[i]!;
 
       if (area > biggest_area) {
         biggest_hint = hint;
@@ -198,4 +200,4 @@ export const pickers = {
 
     return [biggest_hint];
   },
-} satisfies Record<string, (hints: glide.ContentHint[]) => glide.ContentHint[]>;
+} satisfies Record<string, glide.HintPicker>;

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -146,6 +146,8 @@ text-decoration: none;
 [`glide.KeymapContentCallback`](#glide.KeymapContentCallback)\
 [`glide.KeymapCallbackProps`](#glide.KeymapCallbackProps)\
 [`glide.HintLabelGenerator`](#glide.HintLabelGenerator)\
+[`glide.HintPicker`](#glide.HintPicker)\
+[`glide.HintPickerProps`](#glide.HintPickerProps)\
 [`glide.HintLocation`](#glide.HintLocation)\
 [`glide.HintAction`](#glide.HintAction)\
 [`glide.HintActionProps`](#glide.HintActionProps)\
@@ -1184,6 +1186,30 @@ tab_id: number;
     hints: glide.Hint[];
 }) => string[]
 ```
+
+## • `glide.HintPicker` {% id="glide.HintPicker" %}
+
+```typescript {% highlight_prefix="type x = " %}
+(props: glide.HintPickerProps) => glide.Hint[] | Promise<glide.Hint[]>
+```
+
+## • `glide.HintPickerProps` {% id="glide.HintPickerProps" %}
+
+````typescript {% highlight_prefix="type x = {" %}
+hints: glide.Hint[];
+content: {
+    /**
+     * Executes the given callback in the content process to extract properties
+     * from the all elements that are being hinted.
+     *
+     * For example:
+     * ```typescript
+     * const areas = await content.map((element) => element.offsetWidth * element.offsetHeight);
+     * ```
+     */
+    map<R>(cb: (target: HTMLElement, index: number) => R | Promise<R>): Promise<Awaited<R>[]>;
+};
+````
 
 ## • `glide.HintLocation: "content" | "browser-ui"` {% id="glide.HintLocation" %}
 


### PR DESCRIPTION
This makes it more useful generally as you can access `glide`, and more correct so we can support hints across multiple content frames.