### PR TITLE
fix(hints): clear "No hints found" notification when hints are retriggered

### DIFF
--- a/src/glide/browser/base/content/browser-hints.mts
+++ b/src/glide/browser/base/content/browser-hints.mts
@@ -75,6 +75,12 @@ class GlideHintsClass {
 
     const hints = picked_hints.map((hint): GlideResolvedHint => ({ ...hint, label: "" }));
 
+    // Clear "No hints found" notification when hints are found to avoid showing
+    // a stale notification from a previous failed hint attempt
+    if (hints.length > 0) {
+      GlideBrowser.remove_notification("glide-no-hints-found");
+    }
+
     gBrowser.$hints = hints;
     gBrowser.$hints_action = action;
     gBrowser.$hints_location = location;

--- a/src/glide/browser/base/content/test/hints/browser_hints.ts
+++ b/src/glide/browser/base/content/test/hints/browser_hints.ts
@@ -578,3 +578,29 @@ add_task(async function test_hint_action_function__bad_return() {
     );
   });
 });
+
+add_task(async function test_clear_no_hints_notification_on_retrigger() {
+  await GlideTestUtils.reload_config(function _() {
+    glide.keymaps.set("normal", "~", () => glide.hints.show({ selector: "[data-no-such-element]" }));
+  });
+
+  await BrowserTestUtils.withNewTab(FILE, async (_) => {
+    await keys("~");
+
+    await waiter(() => gNotificationBox.getNotificationWithValue("glide-no-hints-found")).ok(
+      "Waiting for 'No hints found' notification to appear",
+    );
+
+    await keys("f");
+    await wait_for_hints();
+
+    await waiter(() => gNotificationBox.getNotificationWithValue("glide-no-hints-found")).is(
+      null,
+      "Notification should be cleared when hints are successfully found",
+    );
+
+    Assert.greater(get_hints().length, 0, "Hints should be visible");
+
+    await keys("<esc>");
+  });
+});


### PR DESCRIPTION
Closes #139 

#### Before
https://github.com/user-attachments/assets/3506d88a-5133-4825-b001-246b5b67a42a

#### After
https://github.com/user-attachments/assets/32deb311-1333-4644-91be-de7ea4c7ab98

Changes 
- Clear the "No hints found" notification after confirming hints exist. 