### PR TITLE
refactor(commandline): avoid unnecessary DOM mutations

### DIFF
--- a/src/glide/browser/base/content/browser-commandline.mts
+++ b/src/glide/browser/base/content/browser-commandline.mts
@@ -85,6 +85,7 @@ export class ExcmdsCompletionSource implements GlideCompletionSource {
           return this.element.classList.contains("focused");
         },
         set_focused(focused) {
+          if (focused === this.is_focused()) return;
           if (focused) {
             this.element.classList.add("focused");
           } else {
@@ -95,6 +96,9 @@ export class ExcmdsCompletionSource implements GlideCompletionSource {
           return !!source.container.hidden || !!this.element.hidden;
         },
         set_hidden(hidden) {
+          if (hidden === this.is_hidden()) {
+            return;
+          }
           this.element.hidden = hidden;
         },
       });
@@ -191,6 +195,7 @@ export class TabsCompletionSource implements GlideCompletionSource<TabCompletion
           return this.element.classList.contains("focused");
         },
         set_focused(focused) {
+          if (focused === this.is_focused()) return;
           if (focused) {
             this.element.classList.add("focused");
           } else {
@@ -201,6 +206,9 @@ export class TabsCompletionSource implements GlideCompletionSource<TabCompletion
           return !!source.container.hidden || !!this.element.hidden;
         },
         set_hidden(hidden) {
+          if (hidden === this.is_hidden()) {
+            return;
+          }
           this.element.hidden = hidden;
         },
       };
@@ -303,6 +311,7 @@ export class CustomCompletionSource implements GlideCompletionSource<CustomCompl
           return this.element.classList.contains("focused");
         },
         set_focused(focused) {
+          if (focused === this.is_focused()) return;
           if (focused) {
             this.element.classList.add("focused");
           } else {
@@ -313,6 +322,9 @@ export class CustomCompletionSource implements GlideCompletionSource<CustomCompl
           return !!source.container.hidden || !!this.element.hidden;
         },
         set_hidden(hidden) {
+          if (hidden === this.is_hidden()) {
+            return;
+          }
           this.element.hidden = hidden;
         },
       });


### PR DESCRIPTION
Closes #137 

**Changes:**
- Added checks before mutating the element

Just to confirm: the commandline browser tests seem to be failing. I tested with and without my changes but it still failled.  

> Notes: there’s also a slightly cleaner alternative using `classList.toggle("focused", focused)` instead of the if/else branches. I kept the explicit checks here to mirror the existing style, but happy to switch to toggle if you prefer.