### PR TITLE
chore: Add a pre-push hook

### DIFF
--- a/scripts/firefox/license-check.mts
+++ b/scripts/firefox/license-check.mts
@@ -39,12 +39,19 @@ const FIXABLE_FILES = [
 const cli = meow({
   importMeta: import.meta,
   allowUnknownFlags: false,
-  flags: { fix: { type: "boolean", default: false } },
+  flags: { fix: { type: "boolean", default: false }, quiet: { type: "boolean", default: false } },
 });
 
 await main();
 
 async function main() {
+  let log;
+  if (cli.flags.quiet) {
+    log = (..._args: any[]) => {};
+  } else {
+    log = console.log;
+  }
+
   const missing: string[] = [];
   const fixed: string[] = [];
   const license = await fs.readFile(Path.join(SCRIPTS_DIR, "firefox", "license.txt"), "utf8").then((contents) =>
@@ -63,15 +70,15 @@ async function main() {
 
     switch (result) {
       case "skip": {
-        console.log(chalk.grey("skip"), "    ", relative_path);
+        log(chalk.grey("skip"), "    ", relative_path);
         break;
       }
       case "success": {
-        console.log(chalk.green("success"), " ", relative_path);
+        log(chalk.green("success"), " ", relative_path);
         break;
       }
       case "fix": {
-        console.log("");
+        log("");
         if (!cli.flags.fix) {
           missing.push(relative_path);
           console.error(chalk.red("missing"), relative_path);
@@ -98,7 +105,7 @@ async function main() {
 
         const abs_path = Path.join(SRC_DIR, relative_path);
         await fs.writeFile(abs_path, header + "\n\n" + (await fs.readFile(abs_path, "utf8")));
-        console.log(chalk.cyan("fixed"), "   ", relative_path);
+        log(chalk.cyan("fixed"), "   ", relative_path);
         break;
       }
       default:
@@ -107,10 +114,10 @@ async function main() {
   }
 
   if (fixed.length) {
-    console.log();
-    console.log("The following files were automatically fixed:");
-    console.log(fixed.map((p) => "  - " + p).join("\n"));
-    console.log();
+    log();
+    log("The following files were automatically fixed:");
+    log(fixed.map((p) => "  - " + p).join("\n"));
+    log();
   }
 
   if (missing.length) {

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Run as many lints as we can without taking up too much time.
+# NOTE: we execute directly from node_modules instead of using pnpm or npx because it's about twice as fast to startup.
+
+set -euo pipefail
+
+PATH="node_modules/.bin:$PATH"
+
+oxlint --deny-warnings 2>/dev/null
+node --no-warnings --experimental-strip-types scripts/firefox/license-check.mts --quiet
+dprint check
+tsc -p scripts/tsconfig.json
+if command -v zizmor &> /dev/null; then
+    zizmor --quiet --no-progress .
+fi

--- a/src/glide/docs/contributing.md
+++ b/src/glide/docs/contributing.md
@@ -1,5 +1,7 @@
 # Contributing
 
+## Building
+
 To build Glide you must have [`Node`](https://nodejs.org/en/blog/release/v24.0.0) v24 and [`pnpm`](https://pnpm.io/installation) installed.
 
 You must also verify that your system has the dependencies that Firefox requires:
@@ -44,6 +46,11 @@ pnpm launch
 > There are lots of arguments you can pass here, run `pnpm launch --help` for the full list.
 
 ## Editor setup
+
+### Pre-push hook
+
+Glide has a pre-push hook that will run many of the lints for you automatically before each `git push`.
+To set it up, run `ln -s ../../scripts/pre-push.sh .git/hooks/pre-push`.
 
 ### Linting
 


### PR DESCRIPTION
I keep forgetting to run all the linters.
This adds a script that runs the fastest ones on each `git push`, and documents how to set it up.