### PR TITLE
docs: add table of contents sidebar

### DIFF
--- a/scripts/build-api-reference.mts
+++ b/scripts/build-api-reference.mts
@@ -66,6 +66,7 @@ async function main() {
       {% styles %}
       ${STYLES}
       {% /styles %}
+      {% toc selector="h1[id], h2[id]" /%}
     `,
     "\n\n",
     markdown`

--- a/src/glide/browser/base/content/docs.mts
+++ b/src/glide/browser/base/content/docs.mts
@@ -98,6 +98,13 @@ export async function markdown_to_html(
     } while (did_replace);
   }
 
+  // Wrap content in article element with data-toc attribute if toc selector is set
+  if (state.toc_selector) {
+    html_body = `<article data-toc="${state.toc_selector}">${html_body}</article>`;
+  } else {
+    html_body = `<article>${html_body}</article>`;
+  }
+
   const rel_to_dist = "../".repeat(props.nested_count - 1).slice(0, -1) || ".";
   const current_href = rel_to_dist + "/" + props.relative_dist_path;
 
@@ -262,6 +269,7 @@ class RenderState {
   head: string[];
   title: string | null = null;
   description: string | null = null;
+  toc_selector: string | null = null;
 
   // this is required to easily support syntax highlighting with markdoc
   //
@@ -309,6 +317,16 @@ class RenderState {
               // @ts-ignore
               config,
             ));
+          },
+        },
+        toc: {
+          description: "Sets the TOC selector for the page",
+          attributes: {
+            selector: { type: String, required: true },
+          },
+          transform: (node) => {
+            this.toc_selector = node.attributes["selector"] as string;
+            return "";
           },
         },
         "api-heading": {

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -19,6 +19,7 @@ margin-bottom: var(--line-height);
 text-decoration: none;
 }
 {% /styles %}
+{% toc selector="h1[id], h2[id]" /%}
 
 > [!IMPORTANT]
 > These reference docs are not complete yet, some symbols and types are missing completely.

--- a/src/glide/docs/autocmds.md
+++ b/src/glide/docs/autocmds.md
@@ -1,3 +1,5 @@
+{% toc selector="h1[id], h2[id]" /%}
+
 # Autocmds
 
 Auto commands let you register functions that will be automatically invoked when a certain event happens within Glide.

--- a/src/glide/docs/changelog.md
+++ b/src/glide/docs/changelog.md
@@ -15,6 +15,8 @@ padding: 0.3em;
 }
 {% /styles %}
 
+{% toc selector="h1[id]" /%}
+
 # Changelog
 
 # 0.1.56a

--- a/src/glide/docs/docs.css
+++ b/src/glide/docs/docs.css
@@ -1046,8 +1046,7 @@ table th, table td {
   top: 0;
   right: 0;
   height: 100vh;
-  min-width: 25ch;
-  max-width: 30ch;
+  width: 30ch;
   padding: calc(var(--line-height) * 2) 1ch calc(var(--line-height)) 1ch;
   background: var(--background-color);
   font-family: var(--font-family);
@@ -1106,6 +1105,47 @@ table th, table td {
 .toc-sidebar nav a[data-level="3"] {
   padding-left: 3ch;
   font-size: 0.75rem;
+}
+
+/* Collapsible TOC groups */
+.toc-group {
+  margin-bottom: 0.25em;
+}
+
+.toc-group-header {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toc-group-header:hover {
+  background: var(--background-color-alt);
+}
+
+.toc-group-icon {
+  font-size: 0.6rem;
+  margin-right: 0.5ch;
+  color: var(--text-color-alt);
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+  width: 1ch;
+  text-align: center;
+}
+
+.toc-group-header a {
+  flex: 1;
+  cursor: pointer;
+}
+
+.toc-group-items {
+  margin-left: 1.5ch;
+  margin-top: 0.25em;
+  overflow: hidden;
+}
+
+.toc-group-items a {
+  padding-left: 0.5ch;
 }
 
 /**

--- a/src/glide/docs/docs.js
+++ b/src/glide/docs/docs.js
@@ -123,50 +123,40 @@
     return window.pagefind_ui;
   };
 
-  /**
-   * TOC configuration per page
-   * Maps page filename to CSS selector for headings to include.
-   * Only headings with `id` attributes are included.
-   *
-   * @example
-   * "api.html": "h1[id], h2[id]"
-   * "keys.html": "h1[id], h2[id], h3[id]"
-   */
-  const TOC_CONFIG = {
-    "api.html": "h1[id], h2[id]",
-    "keys.html": "h1[id], h2[id], h3[id]",
-    "excmds.html": "h1[id], h2[id]",
-    "hints.html": "h1[id], h2[id]",
-    "changelog.html": "h1[id]",
-    "config.html": "h1[id], h2[id]",
-    "autocmds.html": "h1[id], h2[id]",
-  };
-
   function init_toc() {
     const article = document.querySelector("article");
-    if (!article) return;
-
-    const pageName = window.location.pathname.split("/").pop() || "index.html";
-    const selector = TOC_CONFIG[pageName];
-
-    if (!selector) return;
+    if (!article) {
+      return;
+    }
+    const selector = article.getAttribute("data-toc");
     const headings = article.querySelectorAll(selector);
 
-    const tocSidebar = document.createElement("aside");
-    tocSidebar.className = "toc-sidebar";
+    if (!selector || headings.length === 0) {
+      return;
+    }
 
-    const tocTitle = document.createElement("div");
-    tocTitle.className = "toc-sidebar-title";
-    tocTitle.textContent = "On this page";
-    tocSidebar.appendChild(tocTitle);
+    const toc_sidebar = document.createElement("aside");
+    toc_sidebar.className = "toc-sidebar";
 
-    const tocNav = document.createElement("nav");
-    tocSidebar.appendChild(tocNav);
+    const toc_title = document.createElement("div");
+    toc_title.className = "toc-sidebar-title";
+    toc_title.textContent = "On this page";
+    toc_sidebar.appendChild(toc_title);
+
+    const toc_nav = document.createElement("nav");
+    toc_sidebar.appendChild(toc_nav);
+
+    // Build nested structure with collapsible groups
+    let current_group = null;
+    const groups = new Map(); // Map heading id to group container
+    let first_group = null; // Track the first group
 
     headings.forEach((heading) => {
+      const level = parseInt(heading.tagName.charAt(1));
       const link = document.createElement("a");
       link.href = `#${heading.id}`;
-      link.dataset.level = heading.tagName.charAt(1);
+      link.dataset.level = level.toString();
+      link.dataset.headingId = heading.id;
 
       let text = heading.textContent.trim();
       if (text.endsWith("#")) {
@@ -178,103 +168,264 @@
       link.textContent = text;
       link.title = text;
 
-      tocNav.appendChild(link);
+      // If it's a top-level heading (h1), create a new group
+      if (level === 1) {
+        const group_container = document.createElement("div");
+        group_container.className = "toc-group";
+        group_container.dataset.groupId = heading.id;
+
+        const group_header = document.createElement("div");
+        group_header.className = "toc-group-header";
+
+        const expand_icon = document.createElement("span");
+        expand_icon.className = "toc-group-icon";
+        expand_icon.textContent = "▶";
+        group_header.appendChild(expand_icon);
+
+        group_header.appendChild(link);
+        group_header.addEventListener("click", (e) => {
+          // Don't toggle if clicking the link itself or its children
+          if (e.target === link || link.contains(e.target)) {
+            return; // Let the link handle navigation
+          }
+          e.preventDefault();
+          // Only toggle if the group has items
+          const group_items = group_container.querySelector(".toc-group-items");
+          if (group_items && group_items.children.length > 0) {
+            toggle_toc_group(group_container);
+          }
+        });
+
+        const group_items = document.createElement("div");
+        group_items.className = "toc-group-items";
+        group_items.style.display = "none"; // Collapsed by default
+
+        group_container.appendChild(group_header);
+        group_container.appendChild(group_items);
+        toc_nav.appendChild(group_container);
+
+        // Track the first group
+        if (first_group === null) {
+          first_group = group_container;
+        }
+
+        current_group = group_items;
+        groups.set(heading.id, group_container);
+      } else {
+        // It's a nested item (h2, h3, etc.)
+        if (current_group) {
+          current_group.appendChild(link);
+        } else {
+          // If no group exists, just add it directly (shouldn't happen with proper structure)
+          toc_nav.appendChild(link);
+        }
+      }
     });
 
-    const contentContainer = document.querySelector(".content-container");
-    if (contentContainer) {
-      contentContainer.appendChild(tocSidebar);
-    }
+    // Hide collapsible icon for groups with no items
+    groups.forEach((group_container) => {
+      const group_items = group_container.querySelector(".toc-group-items");
+      const has_items = group_items && group_items.children.length > 0;
 
-    init_toc_scroll_tracking(headings, tocNav);
-  }
+      if (!has_items) {
+        const icon = group_container.querySelector(".toc-group-icon");
+        if (icon) {
+          icon.style.display = "none";
+        }
+        const group_header = group_container.querySelector(".toc-group-header");
+        if (group_header) {
+          group_header.style.cursor = "default";
+        }
+        // Remove the empty group_items container
+        if (group_items) {
+          group_items.remove();
+        }
+      }
+    });
 
-  function init_toc_scroll_tracking(headings, tocNav) {
-    const tocSidebar = tocNav.closest(".toc-sidebar");
-    const tocLinks = tocNav.querySelectorAll("a");
-    const visibleHeadings = new Set();
-    let lastActiveId = null;
-
-    function scrollTocToActiveLink(link) {
-      if (!link || !tocSidebar) return;
-
-      const sidebarRect = tocSidebar.getBoundingClientRect();
-      const linkRect = link.getBoundingClientRect();
-
-      // Check if link is outside the visible area of the sidebar
-      const isAbove = linkRect.top < sidebarRect.top + 60;
-      const isBelow = linkRect.bottom > sidebarRect.bottom - 20;
-
-      if (isAbove || isBelow) {
-        // Use scrollTop instead of scrollIntoView to avoid affecting main page scroll
-        const linkOffsetTop = link.offsetTop;
-        const sidebarHeight = tocSidebar.clientHeight;
-        const targetScroll = linkOffsetTop - sidebarHeight / 2 + link.clientHeight / 2;
-
-        tocSidebar.scrollTo({
-          top: Math.max(0, targetScroll),
-          behavior: "smooth",
-        });
+    // Expand the first group by default if it has items
+    if (first_group) {
+      const group_items = first_group.querySelector(".toc-group-items");
+      if (group_items && group_items.children.length > 0) {
+        group_items.style.display = "block";
+        const icon = first_group.querySelector(".toc-group-icon");
+        if (icon) {
+          icon.textContent = "▼";
+        }
+        first_group.classList.add("toc-group-expanded");
       }
     }
 
-    function updateActiveLink() {
-      tocLinks.forEach((link) => link.classList.remove("toc-active"));
+    const content_container = document.querySelector(".content-container");
+    if (content_container) {
+      content_container.appendChild(toc_sidebar);
+    }
 
-      let activeLink = null;
-      let activeId = null;
+    init_toc_scroll_tracking(headings, toc_nav, groups);
+  }
 
-      if (visibleHeadings.size === 0) {
-        let closestHeading = null;
-        let closestDistance = Infinity;
+  function toggle_toc_group(group_container) {
+    const group_items = group_container.querySelector(".toc-group-items");
+    const icon = group_container.querySelector(".toc-group-icon");
+
+    // Don't toggle if there are no items
+    if (!group_items || group_items.children.length === 0) {
+      return;
+    }
+
+    const is_expanded = group_items.style.display !== "none";
+
+    if (is_expanded) {
+      group_items.style.display = "none";
+      if (icon) icon.textContent = "▶";
+      group_container.classList.remove("toc-group-expanded");
+    } else {
+      group_items.style.display = "block";
+      if (icon) icon.textContent = "▼";
+      group_container.classList.add("toc-group-expanded");
+    }
+  }
+
+  function init_toc_scroll_tracking(headings, toc_nav, groups = null) {
+    const toc_sidebar = toc_nav.closest(".toc-sidebar");
+    const toc_links = toc_nav.querySelectorAll("a");
+    const visible_headings = new Set();
+    let last_active_id = null;
+
+    let scroll_animation_frame = null;
+    function scroll_toc_to_active_link(link) {
+      if (!link || !toc_sidebar) return;
+
+      // Cancel any pending scroll animation
+      if (scroll_animation_frame) {
+        cancelAnimationFrame(scroll_animation_frame);
+      }
+
+      scroll_animation_frame = requestAnimationFrame(() => {
+        const sidebar_rect = toc_sidebar.getBoundingClientRect();
+        const link_rect = link.getBoundingClientRect();
+
+        // Use smaller buffer zones for more responsive scrolling
+        const top_buffer = 15;
+        const bottom_buffer = 10;
+
+        // Check if link is outside the visible area of the sidebar
+        const is_above = link_rect.top < sidebar_rect.top + top_buffer;
+        const is_below = link_rect.bottom > sidebar_rect.bottom - bottom_buffer;
+
+        if (is_above || is_below) {
+          // Calculate scroll position relative to the sidebar's scroll container
+          const link_offset_top = link.offsetTop;
+          const sidebar_height = toc_sidebar.clientHeight;
+          const link_height = link.clientHeight;
+
+          let target_scroll;
+          const padding = 10;
+          if (is_above) {
+            target_scroll = link_offset_top - padding;
+          } else {
+            target_scroll = link_offset_top - sidebar_height + link_height + padding;
+          }
+
+          toc_sidebar.scrollTo({
+            top: Math.max(0, Math.min(target_scroll, toc_sidebar.scrollHeight - sidebar_height)),
+            behavior: "smooth",
+          });
+        }
+        scroll_animation_frame = null;
+      });
+    }
+
+    function update_active_link() {
+      toc_links.forEach((link) => link.classList.remove("toc-active"));
+
+      let active_link = null;
+      let active_id = null;
+
+      if (visible_headings.size === 0) {
+        let closest_heading = null;
+        let closest_distance = Infinity;
 
         headings.forEach((heading) => {
           const rect = heading.getBoundingClientRect();
           if (rect.top < 100) {
             const distance = Math.abs(rect.top);
-            if (distance < closestDistance) {
-              closestDistance = distance;
-              closestHeading = heading;
+            if (distance < closest_distance) {
+              closest_distance = distance;
+              closest_heading = heading;
             }
           }
         });
 
-        if (closestHeading) {
-          activeId = closestHeading.id;
-          activeLink = tocNav.querySelector(`a[href="#${activeId}"]`);
-          if (activeLink) activeLink.classList.add("toc-active");
+        if (closest_heading) {
+          active_id = closest_heading.id;
+          active_link = toc_nav.querySelector(`a[href="#${active_id}"]`);
+          if (active_link) active_link.classList.add("toc-active");
         }
       } else {
-        let firstVisible = null;
+        let first_visible = null;
         headings.forEach((heading) => {
-          if (visibleHeadings.has(heading.id) && !firstVisible) {
-            firstVisible = heading;
+          if (visible_headings.has(heading.id) && !first_visible) {
+            first_visible = heading;
           }
         });
 
-        if (firstVisible) {
-          activeId = firstVisible.id;
-          activeLink = tocNav.querySelector(`a[href="#${activeId}"]`);
-          if (activeLink) activeLink.classList.add("toc-active");
+        if (first_visible) {
+          active_id = first_visible.id;
+          active_link = toc_nav.querySelector(`a[href="#${active_id}"]`);
+          if (active_link) active_link.classList.add("toc-active");
+        }
+      }
+
+      // Expand group if active link is inside it, or if the group header itself is active
+      if (active_link && groups) {
+        // Check if this is a group header (h1)
+        const group_container = groups.get(active_id);
+        if (group_container) {
+          // The active item is a group header, expand it
+          const group_items = group_container.querySelector(".toc-group-items");
+          if (group_items && group_items.style.display === "none") {
+            toggle_toc_group(group_container);
+          }
+        } else {
+          // Check if the active link is inside a group
+          const group_container = active_link.closest(".toc-group");
+          if (group_container) {
+            const group_items = group_container.querySelector(".toc-group-items");
+            if (group_items && group_items.style.display === "none") {
+              toggle_toc_group(group_container);
+            }
+          }
         }
       }
 
       // Only scroll TOC when active section changes
-      if (activeLink && activeId !== lastActiveId) {
-        lastActiveId = activeId;
-        scrollTocToActiveLink(activeLink);
+      if (active_link && active_id !== last_active_id) {
+        last_active_id = active_id;
+        scroll_toc_to_active_link(active_link);
       }
+    }
+
+    let update_animation_frame = null;
+    function schedule_update() {
+      if (update_animation_frame) {
+        return;
+      }
+      update_animation_frame = requestAnimationFrame(() => {
+        update_active_link();
+        update_animation_frame = null;
+      });
     }
 
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          visibleHeadings.add(entry.target.id);
+          visible_headings.add(entry.target.id);
         } else {
-          visibleHeadings.delete(entry.target.id);
+          visible_headings.delete(entry.target.id);
         }
       });
-      updateActiveLink();
+      schedule_update();
     }, {
       rootMargin: "-10% 0px -80% 0px",
       threshold: 0,
@@ -282,13 +433,11 @@
 
     headings.forEach((heading) => observer.observe(heading));
 
-    let scrollTimeout;
     window.addEventListener("scroll", () => {
-      clearTimeout(scrollTimeout);
-      scrollTimeout = setTimeout(updateActiveLink, 50);
+      schedule_update();
     }, { passive: true });
 
-    updateActiveLink();
+    update_active_link();
   }
 
   window.addEventListener("DOMContentLoaded", () => {

--- a/src/glide/docs/excmds.md
+++ b/src/glide/docs/excmds.md
@@ -1,3 +1,5 @@
+{% toc selector="h1[id], h2[id], h3" /%}
+
 # Excmds
 
 {% excmd-list /%}


### PR DESCRIPTION
Added a  “On this page” sidebar that provides a quick overview of all sections on the page.

Kept it  configurable , allowing control over which pages include it and which heading levels are shown.

```js
const TOC_CONFIG = {
    // pageName -> css selectors
    "api.html": "h1[id], h2[id]",
  };
```


https://github.com/user-attachments/assets/9951adf3-7dc5-42bd-9441-d4d50b17238b

