### PR TITLE
feat(api): add support for configuring new search engines

### DIFF
--- a/@types/gecko.d.mts
+++ b/@types/gecko.d.mts
@@ -190,6 +190,7 @@ declare type _BroadcastConduit =
   import("../engine/toolkit/components/extensions/ConduitsParent.sys.mjs").BroadcastConduit;
 declare type _ExtensionCommon =
   typeof import("../engine/toolkit/components/extensions/ExtensionCommon.sys.mjs").ExtensionCommon;
+declare type UserSearchEngine = import("../engine/toolkit/components/search/UserSearchEngine.sys.mjs").UserSearchEngine;
 
 declare type GlideHintIPC = import("../src/glide/browser/base/content/hinting.mts").GlideHintIPC;
 
@@ -311,6 +312,8 @@ declare namespace MockedExports {
     "resource://gre/modules/LayoutUtils.sys.mjs": typeof import("../engine/toolkit/modules/LayoutUtils.sys.mjs");
     "resource://gre/modules/Timer.sys.mjs": { setTimeout: typeof setTimeout };
     "resource://gre/modules/NetUtil.sys.mjs": typeof import("../engine/netwerk/base/NetUtil.sys.mjs");
+    "moz-src:///toolkit/components/search/SearchUtils.sys.mjs":
+      typeof import("../engine/toolkit/components/search/SearchUtils.sys.mjs");
   }
 
   interface ChromeUtils {

--- a/src/glide/browser/base/content/GlideTestUtils.sys.mts
+++ b/src/glide/browser/base/content/GlideTestUtils.sys.mts
@@ -50,7 +50,7 @@ class GlideTestUtilsClass {
    * Behaves the same as `BrowserTestUtils.openNewForegroundTab()` but also defines
    * `[Symbol.dispose]()` so you can use it with `using`.
    */
-  async new_tab(uri: string): Promise<BrowserTab> {
+  async new_tab(uri?: string): Promise<BrowserTab> {
     const tab = await g.BrowserTestUtils.openNewForegroundTab(g.gBrowser, uri);
     return Object.assign(tab, {
       [Symbol.dispose]() {

--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -696,6 +696,31 @@ declare global {
       list(types?: glide.AddonType | glide.AddonType[]): Promise<glide.Addon[]>;
     };
 
+    search_engines: {
+      /**
+       * Adds or updates a custom search engine.
+       *
+       * The format matches `chrome_settings_overrides.search_provider`[0] from WebExtension manifests.
+       *
+       * The `search_url` must contain `{searchTerms}` as a placeholder for the search query.
+       *
+       * ```typescript
+       * glide.search_engines.add({
+       *   name: "Discogs",
+       *   keyword: "disc",
+       *   search_url: "https://www.discogs.com/search/?q={searchTerms}",
+       *   favicon_url: "https://www.discogs.com/favicon.ico",
+       * });
+       * ```
+       *
+       * **note**: search engines you add are not removed when this call is removed, you will need to manually remove them
+       *            using `about:preferences#search` for now.
+       *
+       * [0]: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides#search_provider
+       */
+      add(props: Browser.Manifest.WebExtensionManifestChromeSettingsOverridesSearchProviderType): Promise<void>;
+    };
+
     keys: {
       /**
        * Send a key sequence to the browser, simulating physical key presses.

--- a/src/glide/browser/base/content/test/search/browser.toml
+++ b/src/glide/browser/base/content/test/search/browser.toml
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+
+["dist/browser_search_engines.js"]
+https_first_disabled = true

--- a/src/glide/browser/base/content/test/search/browser_search_engines.ts
+++ b/src/glide/browser/base/content/test/search/browser_search_engines.ts
@@ -1,0 +1,310 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/* Any copyright is dedicated to the Public Domain.
+ * https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const ENGINE_NAME = "Glide Test Engine";
+
+function defer_engine_cleanup() {
+  return {
+    async [Symbol.asyncDispose]() {
+      const engine = Services.search.getEngineByName(ENGINE_NAME);
+      if (engine) {
+        await Services.search.removeEngine(engine);
+      }
+    },
+  };
+}
+
+async function focus_address_bar() {
+  if (glide.ctx.os === "macosx") {
+    await keys("<D-l>");
+  } else {
+    await keys("<C-l>");
+  }
+}
+
+add_task(async function test_add_search_engine() {
+  await using _ = defer_engine_cleanup();
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        keyword: "@test",
+        search_url: "https://example.com/search?q={searchTerms}",
+        suggest_url: "https://example.com/suggest?q={searchTerms}",
+      });
+      glide.g.value = true;
+    });
+  });
+
+  await waiter(() => glide.g.value).ok();
+
+  const engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+  is(engine.name, ENGINE_NAME);
+  ok(engine.aliases.includes("@test"), "Keyword was set");
+
+  const submission = engine.getSubmission("test", "application/x-suggestions+json");
+  ok(submission, "Suggest URL is configured");
+  Assert.stringContains(submission.uri.spec, "suggest", "Suggest URL is correct");
+
+  await focus_address_bar();
+  await keys("@test<space>wow");
+  await sleep_frames(10);
+  await keys("<CR>");
+
+  await waiter(() => glide.ctx.url.toString()).is("https://example.com/search?q=wow");
+});
+
+add_task(async function test_add_search_engine_with_multiple_keywords() {
+  await using _ = defer_engine_cleanup();
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        search_url: "https://example.com/search?q={searchTerms}",
+        keyword: ["@first", "@second", "@third"],
+      });
+      glide.g.value = true;
+    });
+  });
+
+  await waiter(() => glide.g.value).ok();
+
+  const engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+  ok(engine.aliases.includes("@first"), "First keyword was set");
+  ok(engine.aliases.includes("@second"), "Second keyword was set");
+  ok(engine.aliases.includes("@third"), "Third keyword was set");
+
+  for (const alias of ["first", "second", "third"]) {
+    await sleep_frames(2);
+
+    using __ = await GlideTestUtils.new_tab();
+
+    await focus_address_bar();
+    await keys(`@${alias}<CR>${alias}`);
+    await sleep_frames(10);
+    await keys("<CR>");
+    await waiter(() => glide.ctx.url.toString()).is(
+      `https://example.com/search?q=${alias}`,
+      `${alias} can be used to search with the custom engine`,
+    );
+  }
+});
+
+add_task(async function test_search_engine_default() {
+  await using _ = defer_engine_cleanup();
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        keyword: "@test",
+        search_url: "https://example.com/search?q={searchTerms}",
+        is_default: true,
+      });
+      glide.g.value = true;
+    });
+  });
+
+  await waiter(() => glide.g.value).ok();
+
+  const engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+
+  await focus_address_bar();
+  await keys("foo<CR>");
+
+  await waiter(() => glide.ctx.url.toString()).is("https://example.com/search?q=foo");
+});
+
+add_task(async function test_search_engine_post_method() {
+  await using _ = defer_engine_cleanup();
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        keyword: "@post",
+        search_url: "https://example.com/search",
+        search_url_post_params: "q={searchTerms}&format=json",
+      });
+      glide.g.value = true;
+    });
+  });
+
+  await waiter(() => glide.g.value).ok();
+
+  const engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+
+  const url = (engine.wrappedJSObject as any).getURLOfType("text/html");
+  is(url.method, "POST", "Should use POST method");
+
+  const submission = engine.getSubmission("test");
+  ok(submission.postData, "Should have POST data");
+
+  const stream = Cc["@mozilla.org/scriptableinputstream;1"]!.createInstance(Ci.nsIScriptableInputStream);
+  stream.init(submission.postData!);
+  is(
+    stream.read(submission.postData!.available()),
+    "q=test&format=json",
+    "POST body should contain search terms and params",
+  );
+});
+
+add_task(async function test_repeated_add_updates_existing_engine() {
+  await using _ = defer_engine_cleanup();
+
+  // ------------- initial configuration
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        keyword: "@old",
+        search_url: "https://old.example.com/search?q={searchTerms}",
+        suggest_url: "https://old.example.com/suggest?q={searchTerms}",
+      });
+      glide.g.value = 1;
+    });
+  });
+  await waiter(() => glide.g.value).is(1);
+
+  var engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+  ok(engine.aliases.includes("@old"), "Initial keyword was set");
+  is(engine.getSubmission("test").uri.spec, "https://old.example.com/search?q=test", "Initial search URL is correct");
+
+  // ------------- update the engine
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        keyword: ["@new", "@also"],
+        search_url: "https://new.example.com/search?q={searchTerms}",
+        suggest_url: "https://new.example.com/suggest?q={searchTerms}",
+      });
+      glide.g.value = 2;
+    });
+  });
+  await waiter(() => glide.g.value).is(2);
+
+  var engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine still exists");
+  ok(engine.aliases.includes("@new"), "New keyword was set");
+  ok(engine.aliases.includes("@also"), "Additional keyword was set");
+  ok(!engine.aliases.includes("@old"), "Old keyword was removed");
+  is(engine.getSubmission("test").uri.spec, "https://new.example.com/search?q=test", "Search URL was updated");
+  Assert.stringContains(
+    engine.getSubmission("test", "application/x-suggestions+json").uri.spec,
+    "new.example.com",
+    "Suggest URL was updated",
+  );
+});
+
+add_task(async function test_search_url_get_params() {
+  await using _ = defer_engine_cleanup();
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        search_url: "https://example.com/search",
+        search_url_get_params: "q={searchTerms}&format=json&lang=en",
+      });
+      glide.g.value = true;
+    });
+  });
+
+  await waiter(() => glide.g.value).ok();
+
+  const engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+
+  const url = (engine.wrappedJSObject as any).getURLOfType("text/html");
+  is(url.method, "GET", "Should use GET method");
+  is(
+    engine.getSubmission("test").uri.spec,
+    "https://example.com/search?q=test&format=json&lang=en",
+    "GET params should be appended to URL",
+  );
+});
+
+add_task(async function test_update_from_get_to_post_params() {
+  await using _ = defer_engine_cleanup();
+
+  // ------------- start with GET params
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        search_url: "https://example.com/search",
+        search_url_get_params: "q={searchTerms}",
+      });
+      glide.g.value = 1;
+    });
+  });
+  await waiter(() => glide.g.value).is(1);
+
+  var engine = Services.search.getEngineByName(ENGINE_NAME);
+  var url = (engine.wrappedJSObject as any).getURLOfType("text/html");
+  is(url.method, "GET", "Initially should use GET method");
+  ok(!engine.getSubmission("test").postData, "Initially should have no POST data");
+
+  // ------------- update to POST params
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        search_url: "https://example.com/search",
+        search_url_post_params: "q={searchTerms}&via=post",
+      });
+      glide.g.value = 2;
+    });
+  });
+  await waiter(() => glide.g.value).is(2);
+
+  var engine = Services.search.getEngineByName(ENGINE_NAME);
+  var url = (engine.wrappedJSObject as any).getURLOfType("text/html");
+  is(url.method, "POST", "After update should use POST method");
+
+  const submission = engine.getSubmission("test");
+  ok(submission.postData, "Should have POST data after update");
+  const stream = Cc["@mozilla.org/scriptableinputstream;1"]!.createInstance(Ci.nsIScriptableInputStream);
+  stream.init(submission.postData!);
+  is(stream.read(submission.postData!.available()), "q=test&via=post", "POST body should contain updated params");
+});
+
+add_task(async function test_suggest_url_get_params() {
+  await using _ = defer_engine_cleanup();
+
+  await GlideTestUtils.reload_config(function _() {
+    glide.autocmds.create("ConfigLoaded", async () => {
+      await glide.search_engines.add({
+        name: "Glide Test Engine",
+        search_url: "https://example.com/search?q={searchTerms}",
+        suggest_url: "https://example.com/suggest",
+        suggest_url_get_params: "q={searchTerms}&type=json",
+      });
+      glide.g.value = true;
+    });
+  });
+
+  await waiter(() => glide.g.value).ok();
+
+  const engine = Services.search.getEngineByName(ENGINE_NAME);
+  ok(engine, "Engine was added");
+  is(
+    engine.getSubmission("test", "application/x-suggestions+json").uri.spec,
+    "https://example.com/suggest?q=test&type=json",
+    "Suggest URL GET params should be appended",
+  );
+});

--- a/src/glide/browser/base/moz.build
+++ b/src/glide/browser/base/moz.build
@@ -22,6 +22,7 @@ BROWSER_CHROME_MANIFESTS += [
     "content/test/navigation/browser.toml",
     "content/test/process/browser.toml",
     "content/test/scrolling/browser.toml",
+    "content/test/search/browser.toml",
     "content/test/split-views/browser.toml",
     "content/test/tutor/browser.toml",
     "content/test/ui/browser.toml",

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -111,6 +111,8 @@ text-decoration: none;
 [`glide.addons`](#glide.addons)\
 [`glide.addons.install()`](#glide.addons.install)\
 [`glide.addons.list()`](#glide.addons.list)\
+[`glide.search_engines`](#glide.search_engines)\
+[`glide.search_engines.add()`](#glide.search_engines.add)\
 [`glide.keys`](#glide.keys)\
 [`glide.keys.send()`](#glide.keys.send)\
 [`glide.keys.next()`](#glide.keys.next)\
@@ -806,6 +808,33 @@ The returned addons can be filtered by type, for example to only return extensio
 ```typescript
 await glide.addons.list("extension");
 ```
+
+## • `glide.search_engines` {% id="glide.search_engines" %}
+
+{% api-heading id="glide.search_engines.add" %}
+glide.search_engines.add(props): Promise<void>
+{% /api-heading %}
+
+Adds or updates a custom search engine.
+
+The format matches `chrome_settings_overrides.search_provider` [0] from WebExtension manifests.
+
+The `search_url` must contain `{searchTerms}` as a placeholder for the search query.
+
+```typescript
+glide.search_engines.add({
+  name: "Discogs",
+  keyword: "disc",
+  search_url:
+    "https://www.discogs.com/search/?q={searchTerms}",
+  favicon_url: "https://www.discogs.com/favicon.ico",
+});
+```
+
+**note**: search engines you add are not removed when this call is removed, you will need to manually remove them
+using `about:preferences#search` for now.
+
+[0]: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides#search_provider
 
 ## • `glide.keys` {% id="glide.keys" %}
 

--- a/src/toolkit/components/search/UserSearchEngine-sys-mjs.patch
+++ b/src/toolkit/components/search/UserSearchEngine-sys-mjs.patch
@@ -1,0 +1,13 @@
+diff --git a/toolkit/components/search/UserSearchEngine.sys.mjs b/toolkit/components/search/UserSearchEngine.sys.mjs
+index 061f511b531669e1ac944377ad8bee2a73348d51..aad2061905dd39b7c4acc7f4cfc069827de65e55 100644
+--- a/toolkit/components/search/UserSearchEngine.sys.mjs
++++ b/toolkit/components/search/UserSearchEngine.sys.mjs
+@@ -201,7 +201,7 @@ export class UserSearchEngine extends SearchEngine {
+       .then(iconURL => {
+         if (iconURL) {
+           this.changeIcon(iconURL.dataURI.spec);
+-        } else if (Object.keys(this._iconMapObj).length) {
++        } else if (Object.keys(this._iconMapObj || {}).length) {
+           // There was an icon before but now there is none.
+           // Remove previous icon in case the origin changed.
+           this._iconMapObj = {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,9 @@
       "chrome://glide/content/browser-excmds.mjs": ["./src/glide/browser/base/content/browser-excmds.mts"],
       "chrome://glide/content/browser-excmds-registry.mjs": [
         "./src/glide/browser/base/content/browser-excmds-registry.mts"
+      ],
+      "moz-src:///toolkit/components/search/SearchEngine.sys.mjs": [
+        "./engine/toolkit/components/search/SearchEngine.sys.mjs"
       ]
     }
   },


### PR DESCRIPTION
the `.patch` to `UserSearchEngine` avoids a redundant warning that happens when loading the search engine due to a race condition.

closes #158
closes #200