### PR TITLE
feat(keys): support Option+key on macOS using event.code

### DIFF
--- a/src/glide/browser/base/content/test/utils/browser_keys.ts
+++ b/src/glide/browser/base/content/test/utils/browser_keys.ts
@@ -410,3 +410,85 @@ add_task(function normalize_is_idempotent() {
     { seed: 1, numRuns: 1000, verbose: true },
   );
 });
+
+add_task(async function test_macos_option_key_events() {
+  is(
+    to_key_notation({
+      key: "π",
+      code: "KeyP",
+      altKey: true,
+    }),
+    "<A-p>",
+    "Option+P on macOS should produce <A-p> using code property",
+  );
+
+  is(
+    to_key_notation({
+      key: "π",
+      code: "",
+      altKey: true,
+    }),
+    "<A-π>",
+    "Option+P with empty code string should fall back to Unicode character in key",
+  );
+
+  is(
+    to_key_notation({
+      key: "π",
+      code: "InvalidCode",
+      altKey: true,
+    }),
+    "<A-invalidcode>",
+    "Option+key with invalid code should use code.toLowerCase() as fallback",
+  );
+
+  is(
+    to_key_notation({
+      key: "˙",
+      code: "KeyH",
+      altKey: true,
+    }),
+    "<A-h>",
+    "Option+H on macOS should produce <A-h> using code property",
+  );
+
+  is(
+    to_key_notation({
+      key: "¬",
+      code: "KeyL",
+      altKey: true,
+    }),
+    "<A-l>",
+    "Option+L on macOS should produce <A-l> using code property",
+  );
+
+  is(
+    to_key_notation({
+      key: "∏",
+      code: "KeyP",
+      altKey: true,
+      shiftKey: true,
+    }),
+    "<A-S-P>",
+    "Option+Shift+P on macOS should produce <A-S-P> using code property",
+  );
+
+  is(
+    to_key_notation({
+      key: "p",
+      code: "KeyP",
+    }),
+    "p",
+    "Non-Alt key with code should ignore code and use key normally",
+  );
+
+  is(
+    to_key_notation({
+      key: " ",
+      code: "Space",
+      altKey: true,
+    }),
+    "<A-space>",
+    "Option+Space should use code.toLowerCase() when code doesn't start with 'Key'",
+  );
+});

--- a/src/glide/browser/base/content/utils/keys.mts
+++ b/src/glide/browser/base/content/utils/keys.mts
@@ -540,7 +540,8 @@ export function event_to_key_notation(event: GlideMappingEvent): string {
   const physical_key = event.altKey && event.code && AppConstants.platform === "macosx"
     ? extract_physical_key_from_code(event.code)
     : null;
-  const special_key = SPECIAL_KEY_MAP.get(event.key) ?? null;
+  const base_key = physical_key ?? event.key;
+  const special_key = SPECIAL_KEY_MAP.get(base_key) ?? null;
 
   // Firefox handles the shift key differently under two circumstances:
   //
@@ -548,7 +549,6 @@ export function event_to_key_notation(event: GlideMappingEvent): string {
   // 2. If the keypress includes other modifiers, e.g. cmd+shift+c then firefox would set `key` to `c`
   //
   // So we just manually make sure the given key has always been uppercased if the shift flag is set.
-  const base_key = physical_key ?? event.key;
   const key = special_key
     ?? (event.shiftKey
         // don't transform keys like `<Bslash>`
@@ -687,7 +687,6 @@ export function parse_modifiers(
     shiftKey: false,
     is_special: false,
     key: keyn,
-    code: "",
   };
 
   if (!keyn.startsWith("<") || !keyn.endsWith(">")) {


### PR DESCRIPTION
Use `event.code` to detect physical keys when Option is pressed on macos, enabling Option+letter keybindings (e.g., `<A-p>`) to work correctly. This matches Vimium's behavior and ensures that `<A-p>` in #217 works as expected on macos. 

