### PR TITLE
refac(keymaps): implement custom F keymap for newtab hints

### DIFF
--- a/src/glide/browser/base/content/browser-hints.mts
+++ b/src/glide/browser/base/content/browser-hints.mts
@@ -190,7 +190,9 @@ class GlideHintsClass {
    * Remove all hints from the DOM tree and switch back to `normal` mode.
    */
   remove_hints() {
-    GlideBrowser._change_mode("normal");
+    if (GlideBrowser.state.mode === "hint") {
+      GlideBrowser._change_mode("normal");
+    }
     this.#clear_hints();
   }
 

--- a/src/glide/browser/base/content/test/hints/browser_hints.ts
+++ b/src/glide/browser/base/content/test/hints/browser_hints.ts
@@ -94,7 +94,8 @@ add_task(async function test_F_opens_new_tab() {
     is(GlideBrowser.state.mode, "normal", "Mode should return to 'normal' after following hint");
 
     if (final_tab_count > initial_tab_count) {
-      gBrowser.removeTab(gBrowser.selectedTab);
+      const new_tab = gBrowser.tabs[gBrowser.tabs.length - 1];
+      gBrowser.removeTab(new_tab);
     }
   });
 });
@@ -438,7 +439,8 @@ add_task(async function test_numeric_hint_generator() {
     is(GlideBrowser.state.mode, "normal", "Mode should return to 'normal' after following hint");
 
     if (final_tab_count > initial_tab_count) {
-      gBrowser.removeTab(gBrowser.selectedTab);
+      const new_tab = gBrowser.tabs[gBrowser.tabs.length - 1];
+      gBrowser.removeTab(new_tab);
     }
   });
 });


### PR DESCRIPTION
Changes:
- Replaces the  `"hint --action=newtab-click"` command with a custom implementation that handles links and non-link elements differently:
  - Links with `href` are opened in new tabs in background
  - Non-link elements are `focused` and `clicked`
- Update mode change to `normal` only when current mode is `hint`
- Update failing tests to handle tab removal correctly

Closes #202 