### PR TITLE
refactor(internal): use `@oxlint/plugins` for the oxlint plugin

### DIFF
--- a/.oxlint-plugin.mjs
+++ b/.oxlint-plugin.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 // glide-plugin.js
-import { definePlugin, defineRule } from "oxlint";
+import { definePlugin, defineRule } from "@oxlint/plugins";
 
 const plugin = definePlugin({
   meta: {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@microsoft/eslint-plugin-sdl": "^1.1.0",
+    "@oxlint/plugins": "^1.43.0",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/hast": "^3.0.4",
     "@types/ini": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@microsoft/eslint-plugin-sdl':
         specifier: ^1.1.0
         version: 1.1.0(eslint@9.38.0)
+      '@oxlint/plugins':
+        specifier: ^1.43.0
+        version: 1.43.0
       '@total-typescript/ts-reset':
         specifier: ^0.6.1
         version: 0.6.1
@@ -508,6 +511,10 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@oxlint/plugins@1.43.0':
+    resolution: {integrity: sha512-hx8aiUIM9firpmHY6XU/MIKcsUvGgFPOKcBgbGUdhAlbOKGWtEYP0hapXIsaNlO0eixmLomNmQWwgjpunc9q7g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@oxlint/win32-arm64@1.41.0':
     resolution: {integrity: sha512-aK+DAcckQsNCOXKruatyYuY/ROjNiRejQB1PeJtkZwM21+8rV9ODYbvKNvt0pW+YCws7svftBSFMCpl3ke2unw==}
@@ -2131,6 +2138,8 @@ snapshots:
 
   '@oxlint/linux-x64-musl@1.41.0':
     optional: true
+
+  '@oxlint/plugins@1.43.0': {}
 
   '@oxlint/win32-arm64@1.41.0':
     optional: true


### PR DESCRIPTION
One of Oxlint's core team here... thank you for using Oxlint JS plugins!

We've made a breaking change in Oxlint v1.46.0. We've moved `definePlugin` and `defineRule` to a separate package `@oxlint/plugins`. We noticed from our ecosystem CI (which includes Glide) that this change breaks you.

This PR:

* Adds a dev dependency `@oxlint/plugins`.
* Imports `definePlugin` and `defineRule` from that package instead of `oxlint`.

This will avoid breakage when you next update Oxlint. This PR does not update Oxlint itself - don't want to impose on you, your call when/if you want to update.

Hope this is helpful.