### PR TITLE
feat(build): default taskbar badge off in release builds, on when developing

### DIFF
--- a/src/browser/moz-configure.patch
+++ b/src/browser/moz-configure.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/moz.configure b/browser/moz.configure
-index c3ebe718fdea69caa6dc9da4a4063e24eade9df2..29bfafa79e6d2644925fbf71687b530bd20ca039 100644
+index e0946a23cd..318c45b2a8 100644
 --- a/browser/moz.configure
 +++ b/browser/moz.configure
-@@ -13,7 +13,11 @@ imply_option("MOZ_NORMANDY", True)
+@@ -13,7 +13,29 @@ imply_option("MOZ_NORMANDY", True)
  imply_option("MOZ_PROFILE_MIGRATOR", True)
  
  
@@ -12,6 +12,24 @@ index c3ebe718fdea69caa6dc9da4a4063e24eade9df2..29bfafa79e6d2644925fbf71687b530b
 +# glide-original
 +# imply_option("MOZ_APP_VENDOR", "Mozilla")
 +# glide-override-end
++
++option(
++    env="GLIDE_RELEASE",
++    nargs="?",
++    help="Set to 1 or true to define GLIDE_RELEASE (release build)",
++)
++
++@depends("GLIDE_RELEASE")
++def glide_release(value):
++    if not value or not len(value):
++        return None
++    v = value[0]
++    if not isinstance(v, str) or v.lower() not in ("1", "true"):
++        return None
++    return True
++
++set_define("GLIDE_RELEASE", glide_release)
++
  imply_option("MOZ_APP_ID", "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}")
  # Include the DevTools client, not just the server (which is the default)
  imply_option("MOZ_DEVTOOLS", "all")

--- a/src/modules/libpref/init/StaticPrefList-yaml.patch
+++ b/src/modules/libpref/init/StaticPrefList-yaml.patch
@@ -1,8 +1,23 @@
 diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
-index a6c49438aaf3464e70bf9c75c2849a6062bd096a..c3876e665fdf048360b1c6ab45288ec61f850b59 100644
+index 5c7ed2b441..ede63fd63b 100644
 --- a/modules/libpref/init/StaticPrefList.yaml
 +++ b/modules/libpref/init/StaticPrefList.yaml
-@@ -8086,6 +8086,35 @@
+@@ -218,6 +218,14 @@
+ #define IS_NOT_MOBILE true
+ #endif
+ 
++#ifdef GLIDE_RELEASE
++#define IS_GLIDE_RELEASE true
++#define IS_NOT_GLIDE_RELEASE false
++#else
++#define IS_GLIDE_RELEASE false
++#define IS_NOT_GLIDE_RELEASE true
++#endif
++
+ #---------------------------------------------------------------------------
+ # Prefs starting with "accessibility."
+ #---------------------------------------------------------------------------
+@@ -8316,6 +8324,35 @@
    value: 0
    mirror: always
  
@@ -31,10 +46,11 @@ index a6c49438aaf3464e70bf9c75c2849a6062bd096a..c3876e665fdf048360b1c6ab45288ec6
 +
 +- name: glide.firefox.taskbar.badge.enabled
 +  type: bool
-+  value: false
++  value: @IS_NOT_GLIDE_RELEASE@
 +  mirror: always
 +
 +# glide-injection-end
  #---------------------------------------------------------------------------
  # Prefs starting with "html5."
  #---------------------------------------------------------------------------
+ 


### PR DESCRIPTION
### Changes
Added an option in `moz.configure` that is available during the build and gets its value from the `GLIDE_RELEASE` environment variable.

That option is used in `StaticPrefList.yaml` to define preprocessor directives `IS_GLIDE_RELEASE` and `IS_NOT_GLIDE_RELEASE`. Their values are set at build time from the `GLIDE_RELEASE` option.

| Build type   | `GLIDE_RELEASE`  | `IS_GLIDE_RELEASE` | `IS_NOT_GLIDE_RELEASE` | Taskbar badge default |
|-------------|----------------------|--------------------|------------------------|------------------------|
| Release     | Yes (`1` or `true`)  | `true`             | `false`                | Off                    |
| Development | No (unset)           | `false`            | `true`                 | On                     |

### Why

- Release: To preserve the current behavior of the badge being off.
- Dev: We want it on, so that we can use badge to differentiate between debug build and release build.