### PR TITLE
refactor(keymaps)!: make <C-j/k> more intuitive

### DIFF
--- a/src/browser/components/customizableui/content/panelUI-inc-xhtml.patch
+++ b/src/browser/components/customizableui/content/panelUI-inc-xhtml.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/components/customizableui/content/panelUI.inc.xhtml b/browser/components/customizableui/content/panelUI.inc.xhtml
-index 6cb22be6526b17d952a90fd414c49a31e9afde7a..33009fa314c4d7431dfdaa1c2521538037339d75 100644
+index 6cb22be6526b17d952a90fd414c49a31e9afde7a..3fe1985f109eb25579a958a8f12a336cc86ae922 100644
 --- a/browser/components/customizableui/content/panelUI.inc.xhtml
 +++ b/browser/components/customizableui/content/panelUI.inc.xhtml
-@@ -146,6 +146,22 @@
+@@ -146,6 +146,37 @@
           noautohide="true"
           nopreventnavboxhide="true"
           role="alert">
@@ -19,6 +19,21 @@ index 6cb22be6526b17d952a90fd414c49a31e9afde7a..33009fa314c4d7431dfdaa1c25215380
 +                     hidden="true">
 +      <popupnotificationcontent id="glide-smooth-scroll-default-notification-content" orient="vertical">
 +        <description id="glide-smooth-scroll-default-description" data-lazy-l10n-id="appmenu-glide-smooth-scroll-default-message"/>
++      </popupnotificationcontent>
++    </popupnotification>
++
++    <popupnotification id="appMenu-glide-visual-tabs-default-notification"
++                     popupid="glide-visual-tabs-default"
++                     data-lazy-l10n-id="appmenu-glide-visual-tabs-default"
++                     data-l10n-attrs="buttonlabel, buttonaccesskey, secondarybuttonlabel, secondarybuttonaccesskey"
++                     closebuttonhidden="true"
++                     dropmarkerhidden="true"
++                     checkboxhidden="true"
++                     buttonhighlight="true"
++                     hasicon="true"
++                     hidden="true">
++      <popupnotificationcontent id="glide-visual-tabs-default-notification-content" orient="vertical">
++        <description id="glide-visual-tabs-default-description" data-lazy-l10n-id="appmenu-glide-visual-tabs-default-message"/>
 +      </popupnotificationcontent>
 +    </popupnotification>
 +

--- a/src/browser/locales/en-US/browser/appMenuNotifications-ftl.patch
+++ b/src/browser/locales/en-US/browser/appMenuNotifications-ftl.patch
@@ -1,8 +1,8 @@
 diff --git a/browser/locales/en-US/browser/appMenuNotifications.ftl b/browser/locales/en-US/browser/appMenuNotifications.ftl
-index 1c2c740744049de44a14664f90191a788c88340f..9ce414d799b67167b9626298516cdc1c38ec818a 100644
+index 1c2c740744049de44a14664f90191a788c88340f..bc16806e683fd0c68d6d93f5209c4c6fe6eae2ec 100644
 --- a/browser/locales/en-US/browser/appMenuNotifications.ftl
 +++ b/browser/locales/en-US/browser/appMenuNotifications.ftl
-@@ -2,6 +2,15 @@
+@@ -2,6 +2,23 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
  
@@ -14,6 +14,14 @@ index 1c2c740744049de44a14664f90191a788c88340f..9ce414d799b67167b9626298516cdc1c
 +    .secondarybuttonaccesskey = C
 +
 +appmenu-glide-smooth-scroll-default-message = Smooth scrolling is now enabled by default.
++
++appmenu-glide-visual-tabs-default =
++    .buttonlabel = Learn more
++    .buttonaccesskey = L
++    .secondarybuttonlabel = :clear
++    .secondarybuttonaccesskey = C
++
++appmenu-glide-visual-tabs-default-message = Tab change keymap directions are now resolved from the vertical/horizontal tabs setting.
 +
  appmenu-update-available2 =
      .label = Update available

--- a/src/glide/browser/base/content/browser-excmds-registry.mts
+++ b/src/glide/browser/base/content/browser-excmds-registry.mts
@@ -180,6 +180,18 @@ export const GLIDE_EXCOMMANDS = [
     repeatable: true,
   },
   {
+    name: "tab_next_visual",
+    description: "Switch to the next tab, taking into account vertical/horizontal tabs",
+    content: false,
+    repeatable: true,
+  },
+  {
+    name: "tab_prev_visual",
+    description: "Switch to the previous tab, taking into account vertical/horizontal tabs",
+    content: false,
+    repeatable: true,
+  },
+  {
     name: "tab_pin",
     description: "Pin the current tab, or the tab with the given ID",
     content: false,

--- a/src/glide/browser/base/content/browser-excmds.mts
+++ b/src/glide/browser/base/content/browser-excmds.mts
@@ -307,6 +307,33 @@ class GlideExcmdsClass {
         gBrowser.selectedTab = gBrowser.tabContainer.allTabs.at(gBrowser.tabContainer.selectedIndex - 1);
         break;
       }
+
+      case "tab_next_visual": {
+        GlideBrowser.notify_tabs_breaking_change?.();
+
+        const glide = GlideBrowser.api;
+        if (glide.prefs.get("sidebar.verticalTabs")) {
+          await glide.excmds.execute("tab_next");
+          return;
+        }
+
+        await glide.excmds.execute("tab_prev");
+        break;
+      }
+
+      case "tab_prev_visual": {
+        GlideBrowser.notify_tabs_breaking_change?.();
+
+        const glide = GlideBrowser.api;
+        if (glide.prefs.get("sidebar.verticalTabs")) {
+          await glide.excmds.execute("tab_prev");
+          return;
+        }
+
+        await glide.excmds.execute("tab_next");
+        break;
+      }
+
       case "tab_pin": {
         const {
           args: { tab_id },

--- a/src/glide/browser/base/content/browser.mts
+++ b/src/glide/browser/base/content/browser.mts
@@ -217,6 +217,10 @@ class GlideBrowserClass {
     });
 
     this.on_startup(async () => {
+      await this.#setup_tabs_breaking_change_notification();
+    });
+
+    this.on_startup(async () => {
       const listener: AddonManagerListener = {
         async onInstalled(addon) {
           await config_promise;
@@ -618,33 +622,12 @@ class GlideBrowserClass {
       return;
     }
 
-    const oldest_version_file = GlideBrowser.api.path.join(
-      GlideBrowser.api.path.profile_dir,
-      "glide__compatibility_oldest_version.txt",
-    );
-    if (!(await GlideBrowser.api.fs.exists(oldest_version_file))) {
-      // this can happen the *very first* time the browser is launched
-      return;
-    }
-    const version_full = await GlideBrowser.api.fs.read(oldest_version_file, "utf8").then((version) =>
-      version.trimEnd()
-    ).catch((err) => {
-      this._log.error("error while reading ", oldest_version_file, err);
-      return null;
-    });
-    if (!version_full) {
-      // something very weird happened if we couldn't read the version file, so just bail
+    const result = await this.#has_version_older_than("0.1.54a");
+    if (result === false) {
       Services.prefs.setBoolPref(pref, true);
       return;
     }
-
-    // strip out the build id, we only care about the actual version
-    const oldest_version = version_full.slice(0, version_full.indexOf("_"));
-    this._log.debug("oldest used version", oldest_version);
-
-    if (Services.vc.compare(oldest_version, "0.1.53a") > 0) {
-      Services.prefs.setBoolPref(pref, true);
-      // oldest version is newer than 0.1.53a, nothing to do as the user never saw the previous instant scroll behaviour
+    if (result == null) {
       return;
     }
 
@@ -670,6 +653,73 @@ class GlideBrowserClass {
         { callback: () => AppMenuNotifications.removeNotification(notification_id) },
       );
     };
+  }
+
+  notify_tabs_breaking_change: (() => void) | null = null;
+
+  async #setup_tabs_breaking_change_notification() {
+    const pref = "glide.notifications.tabs_explicit_to_visual";
+    if (Services.prefs.getBoolPref(pref, false)) {
+      // already notified
+      return;
+    }
+
+    const result = await this.#has_version_older_than("0.1.60a");
+    if (result === false) {
+      Services.prefs.setBoolPref(pref, true);
+      return;
+    }
+    if (result == null) {
+      return;
+    }
+
+    this.notify_tabs_breaking_change = () => {
+      this.notify_tabs_breaking_change = null;
+      Services.prefs.setBoolPref(pref, true);
+
+      // corresponds to the id in engine/browser/components/customizableui/content/panelUI.inc.xhtml
+      const notification_id = "glide-visual-tabs-default";
+
+      AppMenuNotifications.showNotification(
+        notification_id,
+        // main action, the "learn more" button
+        {
+          // note: for some reason, using the `resource://glide-docs/changelog.html` version completely breaks the browser.
+          docs_url: "https://glide-browser.app/changelog#0.1.60a",
+          callback() {
+            AppMenuNotifications.removeNotification(notification_id);
+            gBrowser.addTrustedTab(this.docs_url, { inBackground: false });
+          },
+        },
+        // :clear
+        { callback: () => AppMenuNotifications.removeNotification(notification_id) },
+      );
+    };
+  }
+
+  async #has_version_older_than(compare_version: string): Promise<boolean | null> {
+    const glide = GlideBrowser.api;
+    const oldest_version_file = glide.path.join(glide.path.profile_dir, "glide__compatibility_oldest_version.txt");
+    if (!(await glide.fs.exists(oldest_version_file))) {
+      // this can happen the *very first* time the browser is launched
+      return null;
+    }
+    const version_full = await glide.fs.read(oldest_version_file, "utf8").then((version) => version.trimEnd()).catch(
+      (err) => {
+        this._log.error("error while reading ", oldest_version_file, err);
+        return null;
+      },
+    );
+    if (!version_full) {
+      // something very weird happened if we couldn't read the version file, so just bail
+      return false;
+    }
+
+    // strip out the build id, we only care about the actual version
+    const oldest_version = version_full.slice(0, version_full.indexOf("_"));
+    this._log.debug("oldest used version", oldest_version);
+
+    return Services.vc.compare(oldest_version, compare_version) >= 0;
   }
 
   async #state_change_autocmd(

--- a/src/glide/browser/base/content/plugins/keymaps.mts
+++ b/src/glide/browser/base/content/plugins/keymaps.mts
@@ -68,8 +68,8 @@ export function init(sandbox: Sandbox) {
 
   // tabs
   glide.keymaps.set("normal", "<leader>d", "tab_close");
-  glide.keymaps.set(["normal", "insert"], "<C-j>", "tab_next");
-  glide.keymaps.set(["normal", "insert"], "<C-k>", "tab_prev");
+  glide.keymaps.set(["normal", "insert"], "<C-j>", "tab_next_visual");
+  glide.keymaps.set(["normal", "insert"], "<C-k>", "tab_prev_visual");
   glide.keymaps.set("normal", "<A-p>", "tab_pin_toggle", { description: "Pin or unpin the current tab" });
   glide.keymaps.set("normal", "yt", "tab_duplicate");
 


### PR DESCRIPTION
This more closely maps to existing extensions behaviour, while retaining the current intuitive behaviour for vertical tabs.

TODO:
- [ ] dedicated option to control this behaviour
- [ ] notification for vertical tabs extension usage
- [ ] update tests
- [ ] update docs