### PR TITLE
fix(api/ui): make autohide native tab bar work on macOS

### DIFF
--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -1320,8 +1320,6 @@ declare global {
      *
      * See [firefox-csshacks](https://mrotherguy.github.io/firefox-csshacks/?file=autohide_tabstoolbar_v2.css) for more information.
      *
-     * **warning**: `autohide` does not work on MacOS at the moment.
-     *
      * @default "show"
      */
     native_tabs: "show" | "hide" | "autohide";

--- a/src/glide/browser/base/content/utils/browser-ui.mts
+++ b/src/glide/browser/base/content/utils/browser-ui.mts
@@ -113,6 +113,29 @@ export const autohide_tabstoolbar_v2 = css`
         transition-delay: 0ms, 0ms !important;
       }
     }
+    @media (-moz-platform: macos) {   
+      #navigator-toolbox:hover,
+      #navigator-toolbox:has(#alltabs-button[open]),
+      #navigator-toolbox:has(#alltabs-button[open="true"]) {
+        margin-bottom: 0px !important;
+        >#TabsToolbar {
+            visibility: visible !important;
+            margin-bottom: 0px !important;
+            transition-delay: 0ms, 0ms !important;
+        }
+      }
+      #mainPopupSet:has(
+        #tabContextMenu[open], 
+        #tabContextMenu[open="true"], 
+        #tabContextMenu[state="open"]
+      ) ~ #navigator-toolbox {
+        margin-bottom: 0px !important;
+        > #TabsToolbar {
+            visibility: visible !important;
+            margin-bottom: 0px !important;
+        }  
+      }
+    }
     @media -moz-pref("userchrome.autohidetabs.show-while-inactive.enabled") {
       #navigator-toolbox:-moz-window-inactive {
         margin-bottom: calc(

--- a/src/glide/browser/base/content/utils/browser-ui.mts
+++ b/src/glide/browser/base/content/utils/browser-ui.mts
@@ -62,8 +62,22 @@ export const autohide_tabstoolbar_v2 = css`
     }
   }
   @media not -moz-pref("sidebar.verticalTabs") {
+    :root:not([customizing], [chromehidden~="menubar"]) #navigator-toolbox::before {
+      content: "";
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 16px;
+      background: transparent;
+      pointer-events: auto;
+      z-index: 1;
+    }
+    #mainPopupSet:has(> #tabgroup-preview-panel[panelopen]) ~ #navigator-toolbox::before {
+      pointer-events: none;
+    }
     :root:not([customizing], [chromehidden~="menubar"])
-      #navigator-toolbox:has(> :is(#toolbar-menubar, #TabsToolbar):hover),
+      #navigator-toolbox:is(:hover, :has(> :is(#toolbar-menubar, #TabsToolbar):hover)),
     :root:not([customizing], [chromehidden~="menubar"]) #TabsToolbar {
       margin-bottom: calc(
         0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
@@ -96,12 +110,9 @@ export const autohide_tabstoolbar_v2 = css`
         margin-bottom var(--uc-tabs-hide-animation-duration) ease-out
           var(--uc-tabs-hide-animation-delay) !important;
     }
-    #mainPopupSet:has(
-        > #tab-group-editor > [panelopen],
-        > #tabgroup-preview-panel[panelopen]
-      )
+    #mainPopupSet:has(> #tab-group-editor > [panelopen])
       ~ #navigator-toolbox,
-    #navigator-toolbox:has(> :is(#toolbar-menubar, #TabsToolbar):hover),
+    #navigator-toolbox:is(:hover, :has(> :is(#toolbar-menubar, #TabsToolbar):hover)),
     #navigator-toolbox[movingtab] {
       transition-delay: 0s !important;
       margin-bottom: calc(

--- a/src/glide/browser/base/content/utils/browser-ui.mts
+++ b/src/glide/browser/base/content/utils/browser-ui.mts
@@ -20,12 +20,6 @@ export const autohide_tabstoolbar_v2 = css`
     --uc-tabs-hide-animation-delay: 200ms;
     /* Modification keeping the default behavior and setting a custom collapse width */
     --uc-tab-collapsed-width: var(--tab-collapsed-width);
-    --uc-autohide-tabs-pull-collapsed: calc(
-      0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
-    );
-    --uc-autohide-tabs-pull-hover: calc(
-      0px - var(--tab-block-margin) - var(--tab-min-height)
-    );
   }
 
   @media -moz-pref("sidebar.verticalTabs") {
@@ -68,8 +62,12 @@ export const autohide_tabstoolbar_v2 = css`
     }
   }
   @media not -moz-pref("sidebar.verticalTabs") {
+    :root:not([customizing], [chromehidden~="menubar"])
+      #navigator-toolbox:has(> :is(#toolbar-menubar, #TabsToolbar):hover),
     :root:not([customizing], [chromehidden~="menubar"]) #TabsToolbar {
-      margin-bottom: var(--uc-autohide-tabs-pull-collapsed);
+      margin-bottom: calc(
+        0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
+      );
     }
     #toolbar-menubar:is([autohide=""], [autohide="true"])
       + #TabsToolbar:not(:hover) {
@@ -99,17 +97,16 @@ export const autohide_tabstoolbar_v2 = css`
           var(--uc-tabs-hide-animation-delay) !important;
     }
     #mainPopupSet:has(
-        > #tab-group-editor > [panelopen]
+        > #tab-group-editor > [panelopen],
+        > #tabgroup-preview-panel[panelopen]
       )
       ~ #navigator-toolbox,
-    #navigator-toolbox:is(
-      :hover,
-      :has(> :is(#toolbar-menubar, #TabsToolbar):hover),
-      :has(#alltabs-button[open="true"])
-    ),
+    #navigator-toolbox:has(> :is(#toolbar-menubar, #TabsToolbar):hover),
     #navigator-toolbox[movingtab] {
       transition-delay: 0s !important;
-      margin-bottom: var(--uc-autohide-tabs-pull-hover);
+      margin-bottom: calc(
+        0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
+      );
       > #TabsToolbar {
         visibility: visible;
         margin-bottom: 0px;
@@ -118,7 +115,9 @@ export const autohide_tabstoolbar_v2 = css`
     }
     @media -moz-pref("userchrome.autohidetabs.show-while-inactive.enabled") {
       #navigator-toolbox:-moz-window-inactive {
-        margin-bottom: var(--uc-autohide-tabs-pull-hover);
+        margin-bottom: calc(
+          0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
+        );
         > #TabsToolbar {
           visibility: visible;
           margin-bottom: 0px;

--- a/src/glide/browser/base/content/utils/browser-ui.mts
+++ b/src/glide/browser/base/content/utils/browser-ui.mts
@@ -20,6 +20,12 @@ export const autohide_tabstoolbar_v2 = css`
     --uc-tabs-hide-animation-delay: 200ms;
     /* Modification keeping the default behavior and setting a custom collapse width */
     --uc-tab-collapsed-width: var(--tab-collapsed-width);
+    --uc-autohide-tabs-pull-collapsed: calc(
+      0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
+    );
+    --uc-autohide-tabs-pull-hover: calc(
+      0px - var(--tab-block-margin) - var(--tab-min-height)
+    );
   }
 
   @media -moz-pref("sidebar.verticalTabs") {
@@ -62,26 +68,8 @@ export const autohide_tabstoolbar_v2 = css`
     }
   }
   @media not -moz-pref("sidebar.verticalTabs") {
-    :root:not([customizing], [chromehidden~="menubar"]) #navigator-toolbox::before {
-      content: "";
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 16px;
-      background: transparent;
-      pointer-events: auto;
-      z-index: 1;
-    }
-    #mainPopupSet:has(> #tabgroup-preview-panel[panelopen]) ~ #navigator-toolbox::before {
-      pointer-events: none;
-    }
-    :root:not([customizing], [chromehidden~="menubar"])
-      #navigator-toolbox:is(:hover, :has(> :is(#toolbar-menubar, #TabsToolbar):hover)),
     :root:not([customizing], [chromehidden~="menubar"]) #TabsToolbar {
-      margin-bottom: calc(
-        0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
-      );
+      margin-bottom: var(--uc-autohide-tabs-pull-collapsed);
     }
     #toolbar-menubar:is([autohide=""], [autohide="true"])
       + #TabsToolbar:not(:hover) {
@@ -110,14 +98,18 @@ export const autohide_tabstoolbar_v2 = css`
         margin-bottom var(--uc-tabs-hide-animation-duration) ease-out
           var(--uc-tabs-hide-animation-delay) !important;
     }
-    #mainPopupSet:has(> #tab-group-editor > [panelopen])
+    #mainPopupSet:has(
+        > #tab-group-editor > [panelopen]
+      )
       ~ #navigator-toolbox,
-    #navigator-toolbox:is(:hover, :has(> :is(#toolbar-menubar, #TabsToolbar):hover)),
+    #navigator-toolbox:is(
+      :hover,
+      :has(> :is(#toolbar-menubar, #TabsToolbar):hover),
+      :has(#alltabs-button[open="true"])
+    ),
     #navigator-toolbox[movingtab] {
       transition-delay: 0s !important;
-      margin-bottom: calc(
-        0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
-      );
+      margin-bottom: var(--uc-autohide-tabs-pull-hover);
       > #TabsToolbar {
         visibility: visible;
         margin-bottom: 0px;
@@ -126,9 +118,7 @@ export const autohide_tabstoolbar_v2 = css`
     }
     @media -moz-pref("userchrome.autohidetabs.show-while-inactive.enabled") {
       #navigator-toolbox:-moz-window-inactive {
-        margin-bottom: calc(
-          0px - 2 * var(--tab-block-margin) - var(--tab-min-height)
-        );
+        margin-bottom: var(--uc-autohide-tabs-pull-hover);
         > #TabsToolbar {
           visibility: visible;
           margin-bottom: 0px;

--- a/src/glide/docs/api.md
+++ b/src/glide/docs/api.md
@@ -387,8 +387,6 @@ glide.styles.add(css`
 
 See [firefox-csshacks](https://mrotherguy.github.io/firefox-csshacks/?file=autohide_tabstoolbar_v2.css) for more information.
 
-**warning**: `autohide` does not work on MacOS at the moment.
-
 `ts:@default "show"`
 
 ### `glide.o.newtab_url: string` {% id="glide.o.newtab_url" %}


### PR DESCRIPTION
Solves issue mentioned [here](https://github.com/glide-browser/glide/pull/156#issuecomment-3678443230)

> [!WARNING]
>  There appears to be a bug causing the tab bar to close when hovering over the macOS traffic light buttons. We can postpone merging this for now until the issue is resolved.

Adds a transparent top-edge hover target so collapsed tab bar can reopen reliably on macOS


https://github.com/user-attachments/assets/547d17bd-7269-4211-8715-8377f3130a5b

