### PR TITLE
feat: add support for the gemini:// protocol

### DIFF
--- a/@types/gecko.d.mts
+++ b/@types/gecko.d.mts
@@ -396,6 +396,8 @@ declare namespace MockedExports {
     "resource://devtools/client/framework/browser-toolbox/Launcher.sys.mjs":
       typeof import("../engine/devtools/client/framework/browser-toolbox/Launcher.sys.mjs");
 
+    "resource://gre/modules/XPCOMUtils.sys.mjs": typeof import("../engine/js/xpconnect/loader/XPCOMUtils.sys.mjs");
+
     "resource://gre/modules/Subprocess.sys.mjs":
       typeof import("../engine/toolkit/modules/subprocess/Subprocess.sys.mjs");
     "resource://gre/modules/LayoutUtils.sys.mjs": typeof import("../engine/toolkit/modules/LayoutUtils.sys.mjs");
@@ -425,6 +427,7 @@ declare namespace MockedExports {
     defineModuleGetter: (target: any, variable: string, path: string) => void;
     defineESModuleGetters: (target: any, mappings: any) => void;
     generateQI(interfaces: any[]): MozQueryInterface;
+    domProcessChild: nsIDOMProcessChild | null;
   }
 }
 

--- a/@types/gecko.d.mts
+++ b/@types/gecko.d.mts
@@ -357,6 +357,7 @@ declare namespace MockedExports {
     "chrome://glide/content/bundled/ts-blank-space.mjs": {
       default: typeof import("ts-blank-space").default;
     };
+    "chrome://glide/content/bundled/dioscuri.mjs": { buffer: typeof import("dioscuri").buffer };
 
     "resource://testing-common/DOMFullscreenTestUtils.sys.mjs":
       typeof import("../engine/browser/base/content/test/fullscreen/DOMFullscreenTestUtils.sys.mjs");

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - Web extensions [API](https://glide-browser.app/extensions) support
 - Fuzzy tab manager (try it with `<space><space>`)
 - Site specific [settings](https://glide-browser.app/cookbook#set-a-pref-for-a-specific-website) / [keymaps](https://glide-browser.app/cookbook#override-a-keymap-for-a-specific-website)
+- Support for the [Gemini](https://glide-browser.app/gemini) protocol
 - ... and more
 
 https://github.com/user-attachments/assets/610e8121-8e25-484b-bf1c-8f9f3efd8605

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@markdoc/markdoc": "^0.5.4",
+    "dioscuri": "^1.3.0",
     "shiki": "^3.19.0",
     "ts-blank-space": "^0.6.2",
     "typescript": "^5.9.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@markdoc/markdoc':
         specifier: ^0.5.4
         version: 0.5.4
+      dioscuri:
+        specifier: ^1.3.0
+        version: 1.3.0
       shiki:
         specifier: ^3.19.0
         version: 3.19.0
@@ -682,6 +685,9 @@ packages:
   '@types/markdown-it@12.2.3':
     resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
 
+  '@types/mdast@3.0.15':
+    resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -690,6 +696,9 @@ packages:
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -885,6 +894,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dioscuri@1.3.0:
+    resolution: {integrity: sha512-0b3XsqJOcY9gZMNEjM3r55xDfO9McqnBiDOWg9nVQHS+O46kLE8M/SMjcXOJ4ppFmnc3t4WUcIzen6ZvO60Ekw==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1443,17 +1455,32 @@ packages:
     resolution: {integrity: sha512-JhC3R1f6dbspVtmF3vKjAWz1EVIvwFrGGPLSdU6rK79xBwHWTuHoLnRX/t1/zHS1Ch1Y2UtIrih7DAHuH9JFJA==}
     engines: {node: '>=20'}
 
+  micromark-util-character@1.2.0:
+    resolution: {integrity: sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@1.1.0:
+    resolution: {integrity: sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
+  micromark-util-sanitize-uri@1.2.0:
+    resolution: {integrity: sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==}
+
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
 
+  micromark-util-symbol@1.1.0:
+    resolution: {integrity: sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==}
+
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@1.1.0:
+    resolution: {integrity: sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==}
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
@@ -1870,6 +1897,9 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unist-util-is@5.2.1:
+    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -1879,8 +1909,14 @@ packages:
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
+  unist-util-visit-parents@5.1.3:
+    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
+
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@4.1.2:
+    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
@@ -2342,6 +2378,10 @@ snapshots:
       '@types/mdurl': 2.0.0
     optional: true
 
+  '@types/mdast@3.0.15':
+    dependencies:
+      '@types/unist': 2.0.11
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -2352,6 +2392,8 @@ snapshots:
   '@types/node@24.3.0':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -2563,6 +2605,15 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dioscuri@1.3.0:
+    dependencies:
+      '@types/mdast': 3.0.15
+      '@types/unist': 2.0.11
+      micromark-util-encode: 1.1.0
+      micromark-util-sanitize-uri: 1.2.0
+      unist-util-visit: 4.1.2
+      zwitch: 2.0.4
 
   doctrine@2.1.0:
     dependencies:
@@ -3297,12 +3348,25 @@ snapshots:
 
   meow@14.0.0: {}
 
+  micromark-util-character@1.2.0:
+    dependencies:
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-util-encode@1.1.0: {}
+
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@1.2.0:
+    dependencies:
+      micromark-util-character: 1.2.0
+      micromark-util-encode: 1.1.0
+      micromark-util-symbol: 1.1.0
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
@@ -3310,7 +3374,11 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
+  micromark-util-symbol@1.1.0: {}
+
   micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@1.1.0: {}
 
   micromark-util-types@2.0.2: {}
 
@@ -3812,6 +3880,10 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unist-util-is@5.2.1:
+    dependencies:
+      '@types/unist': 2.0.11
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -3824,10 +3896,21 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  unist-util-visit-parents@5.1.3:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 5.2.1
+
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+
+  unist-util-visit@4.1.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
 
   unist-util-visit@5.0.0:
     dependencies:

--- a/scripts/bundle.mts
+++ b/scripts/bundle.mts
@@ -10,23 +10,27 @@ export async function bundle() {
   await $.no_stdout(async () => {
     await fs.mkdir("src/glide/bundled", { recursive: true });
 
-    const build = async (mod: string, filename: string) => {
-      console.log("+ bundling", mod);
+    const build = async (
+      filename: string,
+      { mod, path }: { mod: string; path?: undefined } | { path: string; mod?: undefined },
+    ) => {
+      console.log("+ bundling", mod ?? path);
       await esbuild.build({
         format: "esm",
         minify: true,
         bundle: true,
-        entryPoints: [fileURLToPath(import.meta.resolve(mod))],
+        entryPoints: mod ? [fileURLToPath(import.meta.resolve(mod))] : [path!],
         outfile: `src/glide/bundled/${filename}`,
       });
     };
 
-    await build("ts-blank-space", "ts-blank-space.mjs");
-    await build("@markdoc/markdoc", "markdoc.mjs");
-    await build("fast-check", "fast-check.mjs");
+    await build("ts-blank-space.mjs", { mod: "ts-blank-space" });
+    await build("markdoc.mjs", { mod: "@markdoc/markdoc" });
+    await build("fast-check.mjs", { mod: "fast-check" });
+    await build("dioscuri.mjs", { path: "scripts/shims/dioscuri.mjs" });
 
     // TODO(glide): only bundle the themes + languages we need
-    await build("shiki", "shiki.mjs");
+    await build("shiki.mjs", { mod: "shiki" });
   });
 
   await bundle_types();

--- a/scripts/shims/dioscuri.mjs
+++ b/scripts/shims/dioscuri.mjs
@@ -1,0 +1,1 @@
+export { buffer } from "dioscuri/lib/buffer";

--- a/src/browser/actors/GeminiProtocolParent.sys.mjs
+++ b/src/browser/actors/GeminiProtocolParent.sys.mjs
@@ -1,0 +1,1 @@
+../../glide/browser/actors/dist/GeminiProtocolParent.sys.mjs

--- a/src/browser/actors/moz-build.patch
+++ b/src/browser/actors/moz-build.patch
@@ -1,11 +1,12 @@
 diff --git a/browser/actors/moz.build b/browser/actors/moz.build
-index 770fdca9d0affea295ce712ca7e3fd9d0138c64f..1082f807e0d1d176d964618b08216508a9d9e268 100644
+index 55e8f81874081e730b8e52ec7b496507e0be1a43..4c3f00c71b862748d81f141de435428afaad4983 100644
 --- a/browser/actors/moz.build
 +++ b/browser/actors/moz.build
-@@ -60,6 +60,12 @@ FINAL_TARGET_FILES.actors += [
+@@ -120,6 +120,13 @@ FINAL_TARGET_FILES.actors += [
      "EncryptedMediaParent.sys.mjs",
      "FormValidationChild.sys.mjs",
      "FormValidationParent.sys.mjs",
++    "GeminiProtocolParent.sys.mjs",
 +    "GlideDocsChild.sys.mjs",
 +    "GlideDocsParent.sys.mjs",
 +    "GlideHandlerChild.sys.mjs",

--- a/src/browser/components/DesktopActorRegistry-sys-mjs.patch
+++ b/src/browser/components/DesktopActorRegistry-sys-mjs.patch
@@ -1,8 +1,22 @@
 diff --git a/browser/components/DesktopActorRegistry.sys.mjs b/browser/components/DesktopActorRegistry.sys.mjs
-index d974112aa90bb5e5e72151de354a2e1ab382e32f..c52546d1a7a743db3def86608e18118758e467a3 100644
+index 059edd72c3b220ee3ec2fa4becf1fa1b67627834..1e3f7bfc1becef5a604a5133098ce00982b40aaa 100644
 --- a/browser/components/DesktopActorRegistry.sys.mjs
 +++ b/browser/components/DesktopActorRegistry.sys.mjs
-@@ -92,6 +92,53 @@ let JSWINDOWACTORS = {
+@@ -41,6 +41,13 @@ let JSPROCESSACTORS = {
+     includeParent: true,
+   },
+ 
++  GeminiProtocol: {
++    parent: {
++      esModuleURI: "resource:///actors/GeminiProtocolParent.sys.mjs",
++    },
++    includeParent: true,
++  },
++
+   RefreshBlockerObserver: {
+     child: {
+       esModuleURI: "resource:///actors/RefreshBlockerChild.sys.mjs",
+@@ -92,6 +99,53 @@ let JSWINDOWACTORS = {
      enablePreference: "browser.contextual-password-manager.enabled",
    },
  

--- a/src/browser/components/gemini/GeminiProtocolHandler.sys.mts
+++ b/src/browser/components/gemini/GeminiProtocolHandler.sys.mts
@@ -1,0 +1,340 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { GeminiProtocolChild } from "../../../glide/browser/actors/GeminiProtocolParent.sys.mjs";
+
+const Strings = ChromeUtils.importESModule("chrome://glide/content/utils/strings.mjs");
+const { buffer: gemtext_to_html } = ChromeUtils.importESModule("chrome://glide/content/bundled/dioscuri.mjs");
+
+export class GeminiProtocolHandler implements nsIProtocolHandler {
+  /**
+   * The protocol scheme handled by this handler.
+   */
+  scheme = "gemini";
+
+  #log: ConsoleInstance = console.createInstance
+    ? console.createInstance({ prefix: "GeminiProtocol", maxLogLevelPref: "glide.gemini.loglevel" })
+    // createInstance isn't defined in tests
+    : (console as any);
+
+  /**
+   * Creates a new channel for handling gemini:// URLs.
+   */
+  newChannel(uri: nsIURI, load_info: nsILoadInfo): nsIChannel {
+    this.#log.debug("newChannel:", uri.spec);
+
+    // https://geminiprotocol.net/docs/protocol-specification.gmi#requests
+    // "If a client is making a request with an empty path, the client SHOULD add a trailing '/' to the request"
+    if (!uri.filePath) {
+      uri = uri.mutate().setFilePath("/").finalize();
+      this.#log.debug("adding a trailing slash:", uri.spec);
+    }
+
+    const stream_channel = Cc["@mozilla.org/network/input-stream-channel;1"]!.createInstance(Ci.nsIInputStreamChannel);
+    const inner_channel = stream_channel.QueryInterface!(Ci.nsIChannel);
+
+    stream_channel.setURI(uri);
+    inner_channel.loadInfo = load_info;
+    inner_channel.contentType = "text/html";
+    inner_channel.contentCharset = "UTF-8";
+    inner_channel.originalURI = uri;
+
+    // `DocumentChannel` calls `newChannel()` in the parent process to determine the content
+    // type for process-switching, then creates a second channel in the content process via
+    // `RecvRedirectToRealChannel`.
+    //
+    // The parent channel's data is just discarded so to avoid making two separate network requests
+    // we just provide empty content in the parent process.
+    if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_DEFAULT) {
+      this.#log.debug("skipping fetch in parent process");
+      this.#write_to_channel("", stream => {
+        stream_channel.contentStream = stream;
+      });
+      return inner_channel;
+    }
+
+    const suspended_channel = Services.io.newSuspendableChannelWrapper(inner_channel);
+    suspended_channel.suspend();
+
+    Promise.resolve()
+      .then(() => this.#connect_and_read_stream(uri))
+      .then(({ header, data }) => {
+        const [status, meta] = Strings.partition(header, " ");
+
+        const content = ((): string => {
+          switch (status[0]) {
+            case "1": {
+              return this.#render_error_page(
+                "Input required",
+                `<p>This Gemini page requires user input, which is not supported yet.</p>`,
+              );
+            }
+            case "2": {
+              if (meta.startsWith("text/gemini")) {
+                return this.#render_gemtext(data);
+              }
+              return this.#render_error_page(
+                "Unknown mime type",
+                `<p>This page uses the MIME type <code>${escape_html(meta)}</code>, which is not supported yet.</p>`,
+              );
+            }
+            case "3": {
+              const link = escape_html(meta);
+              const rendered_link = meta.startsWith("gemini://") || meta.startsWith("https://")
+                ? `<a href="${link}">${link}</a>`
+                : `<code>${link}</code>`;
+              return this.#render_error_page(
+                "Redirect",
+                `<p>This page redirects to ${rendered_link}. Automatic redirects are not supported yet.</p>`,
+              );
+            }
+            case "4": {
+              return this.#render_error_page(
+                "Temporary failure",
+                `<p>The server encountered a temporary issue and could not fulfill the request.${
+                  meta ? ` Server message: ${escape_html(meta)}` : ""
+                }</p>`,
+              );
+            }
+            case "5": {
+              return this.#render_error_page(
+                "Permanent failure",
+                `<p>The server could not fulfill the request.${
+                  meta ? ` Server message: ${escape_html(meta)}` : ""
+                } </p>`,
+              );
+            }
+            case "6": {
+              return this.#render_error_page(
+                "Client authentication required",
+                `<p>This page requires authentication, which is not supported yet.${
+                  meta ? ` Server message: ${escape_html(meta)}` : ""
+                }</p>`,
+              );
+            }
+            default: {
+              return this.#render_error_page(
+                "Unknown response",
+                `<p>The server returned an unrecognized status code: <code>${escape_html(status)}</code></p>`,
+              );
+            }
+          }
+        })();
+
+        this.#write_to_channel(content, stream => {
+          stream_channel.contentStream = stream;
+          suspended_channel.resume();
+        });
+      })
+      .catch(error => {
+        this.#log.error(error);
+
+        const content = this.#render_error_page(
+          "Connection Failed",
+          `<p>Could not connect to the Gemini server at <code>${escape_html(uri.host)}</code>. ${
+            escape_html(Error.isError(error) ? error.message : String(error))
+          }</p>`,
+        );
+
+        this.#write_to_channel(content, stream => {
+          stream_channel.contentStream = stream;
+          suspended_channel.resume();
+        });
+      });
+
+    return suspended_channel;
+  }
+
+  /**
+   * Determines whether a given port is allowed for this protocol.
+   */
+  allowPort(port: number, _scheme: string) {
+    // see `src/glide/browser/actors/GeminiProtocolParent.sys.mts:#connect_to_uri` for details on connection handling.
+    return port === 1965;
+  }
+
+  async #connect_and_read_stream(uri: nsIURI): Promise<{ header: string; data: string }> {
+    const actor = this.#get_actor();
+    if (!actor) {
+      throw new Error("The GeminiProtocol process actor is unavailable.");
+    }
+
+    const result = await actor.sendQuery("Glide::Query::GetContent", { url: uri.spec });
+    if (!result.success) {
+      throw new Error(result.error || "Could not connect or read the server response");
+    }
+
+    const [header, data] = Strings.partition(result.content, "\r\n");
+    this.#log.debug(`${uri.spec} response`, { header, data });
+    return { header, data };
+  }
+
+  #get_actor(): GeminiProtocolChild | null {
+    try {
+      return ChromeUtils.domProcessChild!.getActor("GeminiProtocol") as any as GeminiProtocolChild;
+    } catch {
+      return null;
+    }
+  }
+
+  #write_to_channel(content: string, callback: (stream: nsIInputStream) => void) {
+    const sis = Cc["@mozilla.org/io/string-input-stream;1"]!.createInstance(Ci.nsIStringInputStream);
+    sis.setUTF8Data(content);
+    callback(sis);
+  }
+
+  #render_gemtext(gemtext: string): string {
+    return `
+      <head>
+        <style>${STYLES}</style>
+        <meta http-equiv="Content-Security-Policy" content="script-src 'none'">
+      </head>
+      <body class="gemini">
+    ` + gemtext_to_html(escape_quoted_gemtext(gemtext))
+      + `</body>`;
+  }
+
+  #render_error_page(title: string, body_html: string): string {
+    return `
+      <head>
+        <style>${STYLES}</style>
+      </head>
+      <body class="gemini">
+        <h1>${escape_html(title)}</h1>
+        ${body_html}
+      </body>
+    `;
+  }
+
+  QueryInterface = ChromeUtils.generateQI(["nsIProtocolHandler"]);
+}
+
+function escape_html(s: unknown): string {
+  // note: firefox does vendor `lit` but we can't use that here as it depends on a `window` being available
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escape_quoted_gemtext(gemtext: string): string {
+  let in_preformatted_block = false;
+
+  return gemtext
+    .split(/(\r\n|\r|\n)/)
+    .map((part, index) => {
+      if (index % 2 === 1) {
+        return part;
+      }
+
+      if (part.startsWith("```")) {
+        in_preformatted_block = !in_preformatted_block;
+        return part;
+      }
+
+      if (in_preformatted_block || !part.startsWith(">")) {
+        return part;
+      }
+
+      const match = /^(>[ \t]*)(.*)$/.exec(part);
+      if (!match) {
+        return part;
+      }
+
+      const [, prefix, text] = match;
+      return text ? prefix + escape_html(text) : part;
+    })
+    .join("");
+}
+
+const STYLES = `
+  html {
+    margin: 20px;
+  }
+  
+  body {
+    margin: auto;
+    max-width: 800px;
+    -webkit-text-size-adjust: 100%;
+  }
+  
+  div {
+    margin-bottom: 0.6em;
+  }
+  
+  img {
+    max-width: 300px;
+  }
+  
+  details {
+    margin-top: 1em;
+  }
+  
+  details summary {
+    font-style: italic;
+  }
+  
+  .gemini {
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+  
+  .gemini > * {
+    margin: 0;
+  }
+  
+  .gemini > p {
+    white-space: pre-wrap;
+  }
+  
+  .gemini span {
+    font-size: smaller;
+  }
+  
+  .gemini > pre {
+    padding: 5px;
+    width: 100%;
+    box-sizing: border-box;
+    overflow-x: scroll;
+  }
+  
+  .gemini code {
+    border: solid 1px;
+    padding: 1px 2px;
+    margin: 1px 2px;
+  }
+  
+  .gemini a {
+    line-height: 1.5em;
+  }
+  
+  .gemini > blockquote {
+    white-space: pre-wrap;
+    font-style: italic;
+    border-left: 1px solid;
+    padding-left: 10px;
+  }
+  
+  .gemini > h1 {
+    font-size: 1.5em;
+  }
+  
+  .gemini > h2 {
+    font-size: 1.25em;
+  }
+  
+  .gemini > h3 {
+    font-size: 1.1em;
+  }
+  
+  .gemini > ul {
+    padding-left: 1em;
+  }
+  
+  .gemini > figure {
+    margin-bottom: 1em;
+  }
+`;

--- a/src/browser/components/gemini/components.conf
+++ b/src/browser/components/gemini/components.conf
@@ -1,0 +1,22 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Classes = [
+    {
+        "cid": "{b4906fed-dfa5-40f5-ae34-f78f9c658ae0}",
+        "contract_ids": ["@mozilla.org/network/protocol;1?name=gemini"],
+        "esModule": "moz-src:///browser/components/gemini/dist/GeminiProtocolHandler.sys.mjs",
+        "constructor": "GeminiProtocolHandler",
+        "protocol_config": {
+            "scheme": "gemini",
+            "flags": [
+              "URI_STD",
+              "URI_LOADABLE_BY_ANYONE",
+            ],
+            "default_port": 1965,
+        },
+    },
+]

--- a/src/browser/components/gemini/moz.build
+++ b/src/browser/components/gemini/moz.build
@@ -1,0 +1,17 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+MOZ_SRC_FILES += [
+    "dist/GeminiProtocolHandler.sys.mjs",
+]
+
+XPCOM_MANIFESTS += [
+    "components.conf",
+]
+
+BROWSER_CHROME_MANIFESTS += [
+    "test/browser.toml",
+]

--- a/src/browser/components/gemini/test/browser.toml
+++ b/src/browser/components/gemini/test/browser.toml
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[DEFAULT]
+head = "dist/head.js"
+support-files = [
+  "../../../../netwerk/test/unit/client-cert.p12",
+]
+
+["dist/browser_gemini_protocol.js"]

--- a/src/browser/components/gemini/test/browser_gemini_protocol.ts
+++ b/src/browser/components/gemini/test/browser_gemini_protocol.ts
@@ -1,0 +1,270 @@
+// -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+declare var content: TestContent;
+
+// defined in head.ts
+declare var spinup_gemini_server: (responses: Record<string, string>) => Promise<void>;
+
+registerCleanupFunction(() => {
+  glide.prefs.clear("glide.gemini.notified_experimental");
+});
+
+async function setup() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["glide.gemini.notified_experimental", true],
+    ],
+  });
+}
+
+add_task(async function test_gemini_success_response() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/": "20 text/gemini\r\n# Hello World\r\nWelcome to Gemini!",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Hello World", "Heading matches gemtext content");
+
+    const paragraph = content.document.querySelector("p");
+    ok(paragraph);
+    is(paragraph.textContent, "Welcome to Gemini!", "Paragraph matches gemtext content");
+  });
+});
+
+add_task(async function test_gemini_empty_path_adds_trailing_slash() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/": "20 text/gemini\r\n# Trailing Slash\r\nThe empty path resolves to /.",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Trailing Slash", "Empty Gemini paths are normalized to /");
+  });
+});
+
+add_task(async function test_gemini_not_found() {
+  await setup();
+  await spinup_gemini_server({});
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/nonexistent");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Permanent failure", "Shows error for 5x status");
+  });
+});
+
+add_task(async function test_gemini_success_response_decodes_utf8() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/utf8": "20 text/gemini\r\n# H\xc3\xa9llo\r\ncaf\xc3\xa9",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/utf8");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Héllo", "Heading is decoded as UTF-8");
+
+    const paragraph = content.document.querySelector("p");
+    ok(paragraph);
+    is(paragraph.textContent, "café", "Body text is decoded as UTF-8");
+  });
+}).skip();
+
+add_task(async function test_gemini_strips_fragments_from_requests() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/fragment": "20 text/gemini\r\n# Fragment\r\nRequests omit URI fragments.",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/fragment#ignored");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Fragment", "Gemini requests are sent without the fragment");
+  });
+});
+
+add_task(async function test_gemini_quote_text_is_escaped() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/quoted-script": "20 text/gemini\r\n> <script>window.geminiInjected = true</script>",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/quoted-script");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const quote = content.document.querySelector("blockquote p");
+    ok(quote);
+    is(quote.textContent, "<script>window.geminiInjected = true</script>", "Quoted markup is rendered as literal text");
+
+    is(content.document.querySelector("script"), null, "Quoted markup does not create script elements");
+    is((content as any).geminiInjected, undefined, "Quoted markup does not execute scripts in the page");
+  });
+});
+
+add_task(async function test_gemini_preformatted_blocks_do_not_turn_quotes_into_blockquotes() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/preformatted-quote":
+      "20 text/gemini\r\n```\r\n> <script>window.geminiInjected = true</script>\r\n```",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/preformatted-quote");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const pre = content.document.querySelector("pre");
+    ok(pre);
+    ok(
+      pre.textContent?.includes("> <script>window.geminiInjected = true</script>"),
+      "Preformatted text keeps the quoted line literal",
+    );
+
+    is(content.document.querySelector("blockquote"), null, "Preformatted quoted text is not rendered as a blockquote");
+    is(content.document.querySelector("script"), null, "Preformatted markup does not create script elements");
+    is((content as any).geminiInjected, undefined, "Preformatted markup does not execute scripts in the page");
+  });
+});
+
+add_task(async function test_gemini_input_required() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/input-required": "10 Search query\r\n",
+  });
+
+  await assert_error_page(
+    "gemini://127.0.0.1/input-required",
+    "Input required",
+    "This Gemini page requires user input, which is not supported yet.",
+  );
+});
+
+add_task(async function test_gemini_unknown_mime_type() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/html":
+      "20 text/html; charset=\"utf-8\"><script>window.geminiInjected = true</script>\r\n<html></html>",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/html");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Unknown mime type", "Unsupported MIME types show an error page");
+
+    const code = content.document.querySelector("code");
+    ok(code);
+    is(
+      code.textContent,
+      "text/html; charset=\"utf-8\"><script>window.geminiInjected = true</script>",
+      "The unsupported MIME type is displayed as text",
+    );
+
+    is(content.document.querySelector("script"), null, "Unsupported MIME metadata does not create script elements");
+    is((content as any).geminiInjected, undefined, "Unsupported MIME metadata does not execute scripts");
+  });
+});
+
+add_task(async function test_gemini_redirect_response() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/redirect": "30 gemini://127.0.0.1/target\r\n",
+  });
+
+  using tab = await GlideTestUtils.new_tab("gemini://127.0.0.1/redirect");
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [], async () => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, "Redirect", "3x responses show a redirect page");
+
+    const link = content.document.querySelector("a");
+    ok(link);
+    is(link.textContent, "gemini://127.0.0.1/target", "Redirect target is shown to the user");
+    is(link.getAttribute("href"), "gemini://127.0.0.1/target", "Redirect target link points at the Gemini URL");
+  });
+});
+
+add_task(async function test_gemini_temporary_failure() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/temporary-failure": "40 Slow down\r\n",
+  });
+
+  await assert_error_page("gemini://127.0.0.1/temporary-failure", "Temporary failure", "Server message: Slow down");
+});
+
+add_task(async function test_gemini_client_auth_required() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/client-cert": "60 Certificate required\r\n",
+  });
+
+  await assert_error_page(
+    "gemini://127.0.0.1/client-cert",
+    "Client authentication required",
+    "Server message: Certificate required",
+  );
+});
+
+add_task(async function test_gemini_unknown_status_code() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/unknown-status": "99 Unexpected\r\n",
+  });
+
+  await assert_error_page(
+    "gemini://127.0.0.1/unknown-status",
+    "Unknown response",
+    "The server returned an unrecognized status code: 99",
+  );
+});
+
+add_task(async function test_gemini_can_be_disabled() {
+  await setup();
+  await spinup_gemini_server({
+    "gemini://127.0.0.1/": "20 text/gemini\r\n# Hello World\r\nWelcome to Gemini!",
+  });
+
+  glide.prefs.set("glide.gemini.enabled", false);
+
+  await assert_error_page(
+    "gemini://127.0.0.1/input-required",
+    "Connection Failed",
+    "Gemini protocol support has been disabled",
+  );
+
+  glide.prefs.clear("glide.gemini.enabled");
+});
+
+async function assert_error_page(url: string, expected_title: string, expected_text: string) {
+  using tab = await GlideTestUtils.new_tab(url);
+
+  await SpecialPowers.spawn(tab.linkedBrowser, [expected_title, expected_text], async (title, text) => {
+    const h1 = content.document.querySelector("h1");
+    ok(h1);
+    is(h1.textContent, title, `Shows the ${title} heading`);
+
+    const body_text = content.document.body?.textContent;
+    ok(body_text?.includes(text), `Body includes "${text}"`);
+  });
+}

--- a/src/browser/components/gemini/test/head.ts
+++ b/src/browser/components/gemini/test/head.ts
@@ -1,0 +1,97 @@
+// -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+declare var NetUtil: MockedExports.KnownModules["resource://gre/modules/NetUtil.sys.mjs"]["NetUtil"];
+declare var getTestFilePath: (path: string) => string;
+
+const cert_overrides = Cc["@mozilla.org/security/certoverride;1"]!.getService(Ci.nsICertOverrideService);
+
+let servers: nsITLSServerSocket[] = [];
+
+async function spinup_gemini_server(responses: Record<string, string>) {
+  const cert = get_test_server_certificate();
+  const server = start_gemini_server(cert, responses);
+  store_cert_override(server.port, cert);
+  Services.prefs.setIntPref("glide.gemini.test.port", server.port);
+  servers.push(server);
+}
+
+function get_test_server_certificate(): nsIX509Cert {
+  const cert_db = Cc["@mozilla.org/security/x509certdb;1"]!.getService(Ci.nsIX509CertDB);
+  const cert_file = Cc["@mozilla.org/file/local;1"]!.createInstance(Ci.nsIFile);
+  cert_file.initWithPath(getTestFilePath("../client-cert.p12"));
+  cert_db.importPKCS12File(cert_file, "password");
+  for (const cert of cert_db.getCerts()) {
+    if (cert.commonName == "Test End-entity") {
+      return cert;
+    }
+  }
+  throw new Error("could not find test certificate");
+}
+
+function store_cert_override(port: number, cert: nsIX509Cert) {
+  cert_overrides.rememberValidityOverride("127.0.0.1", port, {}, cert, true);
+}
+
+function start_gemini_server(cert: nsIX509Cert, responses: Record<string, string>) {
+  const server = Cc["@mozilla.org/network/tls-server-socket;1"]!.createInstance(Ci.nsITLSServerSocket);
+  server.init(-1, true, -1);
+  server.serverCert = cert;
+
+  server.setSessionTickets(false);
+  server.setRequestClientCertificate(Ci.nsITLSServerSocket.REQUEST_NEVER);
+
+  server.asyncListen({
+    onSocketAccepted(_socket, transport) {
+      const input = transport.openInputStream(0, 0, 0) as nsIAsyncInputStream;
+      const output = transport.openOutputStream(0, 0, 0);
+
+      const conn_info = transport.securityCallbacks.getInterface(Ci.nsITLSServerConnectionInfo);
+      conn_info.setSecurityObserver({
+        onHandshakeDone() {
+          input.QueryInterface!(Ci.nsIAsyncInputStream);
+          input.asyncWait(
+            {
+              onInputStreamReady(stream: nsIInputStream) {
+                try {
+                  const request = NetUtil.readInputStreamToString(stream, stream.available());
+                  const url = request.replace(/\r\n$/, "");
+                  const body = responses[url] ?? "51 Not found\r\n";
+                  output.write(body, body.length);
+                } finally {
+                  output.close();
+                  input.close();
+                }
+              },
+            },
+            0,
+            0,
+            Services.tm.currentThread,
+          );
+        },
+      });
+    },
+    onStopListening() {},
+  });
+
+  return server;
+}
+
+registerCleanupFunction(() => {
+  Services.prefs.clearUserPref("glide.gemini.test.port");
+
+  const to_cleanup = servers;
+  servers = [];
+  for (const server of to_cleanup) {
+    server.close();
+  }
+});
+
+// avoid annoying "not used" warnings
+if (false as any) {
+  spinup_gemini_server({});
+}

--- a/src/browser/components/moz-build.patch
+++ b/src/browser/components/moz-build.patch
@@ -1,0 +1,12 @@
+diff --git a/browser/components/moz.build b/browser/components/moz.build
+index 63b59082d8c8be455530f81ed19d8fac49937200..848fb5fdb32704502e419a256c8dc233d401248e 100644
+--- a/browser/components/moz.build
++++ b/browser/components/moz.build
+@@ -42,6 +42,7 @@ DIRS += [
+     "enterprisepolicies",
+     "extensions",
+     "firefoxview",
++    "gemini",
+     "genai",
+     "ipprotection",
+     "messagepreview",

--- a/src/glide/browser/actors/GeminiProtocolParent.sys.mts
+++ b/src/glide/browser/actors/GeminiProtocolParent.sys.mts
@@ -1,0 +1,251 @@
+// -*- indent-tabs-mode: nil; js-indent-level: 2 -*-
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert_never } = ChromeUtils.importESModule("chrome://glide/content/utils/guards.mjs");
+const { NetUtil } = ChromeUtils.importESModule("resource://gre/modules/NetUtil.sys.mjs");
+
+export interface ChildMessages {}
+export interface ChildQueries {
+  "Glide::Query::GetContent": {
+    props: { url: string };
+    result: { success: false; error: string } | { success: true; content: string };
+  };
+}
+export interface ParentMessages {}
+export interface ParentQueries {}
+
+export type GeminiProtocolChild = JSProcessActorChild<ChildMessages, ChildQueries>;
+
+const DEFAULT_PORT = 1965;
+const NOTIFIED_EXPERIMENTAL_PREF = "glide.gemini.notified_experimental";
+
+export class GeminiProtocolParent extends JSProcessActorParent<ParentMessages, ParentQueries> {
+  #log: ConsoleInstance = null as any;
+
+  actorCreated() {
+    this.#log = console.createInstance({ prefix: "GeminiProtocol[Parent]", maxLogLevelPref: "glide.gemini.loglevel" });
+  }
+
+  async receiveMessage(
+    message: ActorReceiveMessage<ChildMessages, ChildQueries>,
+  ) {
+    this.#log.debug("receiveMessage", message.name);
+
+    switch (message.name) {
+      case "Glide::Query::GetContent": {
+        return await this.get_content(message.data).then((content) => ({ success: true, content })).catch((error) => {
+          this.#log.error(error);
+          return { success: false, error: Error.isError(error) ? error.message : String(error) };
+        });
+      }
+
+      default:
+        throw assert_never(message.name);
+    }
+  }
+
+  async get_content(
+    props: ChildQueries["Glide::Query::GetContent"]["props"],
+  ): Promise<string> {
+    if (!Services.prefs.getBoolPref("glide.gemini.enabled", true)) {
+      throw new Error(`Gemini protocol support has been disabled`);
+    }
+
+    const uri = Services.io.newURI(props.url);
+    if (uri.scheme !== "gemini") {
+      throw new Error(`Expected scheme gemini, but got ${uri.scheme}`);
+    }
+
+    if (uri.port !== -1 && uri.port !== DEFAULT_PORT) {
+      throw new Error(`For security reasons, Gemini can only connect to port ${DEFAULT_PORT}`);
+    }
+
+    if (!Services.prefs.getBoolPref(NOTIFIED_EXPERIMENTAL_PREF, false)) {
+      await this.#prompt_experimental();
+    }
+
+    const stream = await this.#connect_to_uri(uri);
+    return await this.#read_stream(stream);
+  }
+
+  #read_stream(stream: nsIInputStream): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const chunks: string[] = [];
+
+      const pump = Cc["@mozilla.org/network/input-stream-pump;1"]!.createInstance(Ci.nsIInputStreamPump);
+      pump.init(stream, 0, 0, false);
+      pump.asyncRead({
+        onStartRequest() {},
+        onDataAvailable(_request: any, inputStream: nsIInputStream, _offset: number, count: number) {
+          chunks.push(NetUtil.readInputStreamToString(inputStream, count));
+        },
+        onStopRequest(_request: any, status: number) {
+          if (Components.isSuccessCode(status)) {
+            const bytes = chunks.join("");
+            const decoder = new TextDecoder("utf-8");
+            resolve(decoder.decode(new Uint8Array(Array.from(bytes, (ch) => ch.charCodeAt(0)))));
+          } else {
+            reject(new Error(`Stream read failed with status ${status}`));
+          }
+        },
+      });
+    });
+  }
+
+  /**
+   * The gemini protocol[0] does not dictate a particular method for validating TLS server certificates, but it
+   * does recommend TOFU. Additionally all gemini servers I have checked do use self-signed certificates.
+   *
+   * Unfortunately Firefox does not have any builtin implementation of TOFU, so for now we just disable
+   * certificate validation by automatically adding exemptions for the certificate the server provides.
+   *
+   * We only support connecting to the 1965 port to avoid adding exemptions for any certificates that could
+   * reasonably be used for non-gemini schemes.
+   *
+   * In the future we plan to strengthen this further, likely by implemented a proper TOFU system.
+   *
+   * [0]: https://geminiprotocol.net/docs/protocol-specification.gmi#tls-server-certificate-validation
+   */
+  async #connect_to_uri(uri: nsIURI, from_retry = false): Promise<nsIInputStream> {
+    const actor = this;
+
+    // https://geminiprotocol.net/docs/protocol-specification.gmi#requests
+    // "Clients MUST NOT send a fragment as part of the request"
+    const url = uri.specIgnoringRef;
+    const hostname = uri.host;
+
+    // when the browser is ran for tests we allow non-default ports so we can hit our test server
+    const port = Services.prefs.getBoolPref("devtools.testing", false)
+      ? Services.prefs.getIntPref("glide.gemini.test.port", 0) || DEFAULT_PORT
+      : DEFAULT_PORT;
+
+    this.#log.debug("connecting to", { url, hostname, port });
+
+    const sts = Cc["@mozilla.org/network/socket-transport-service;1"]!.getService(Ci.nsISocketTransportService);
+    const transport = sts.createTransport(["ssl"], hostname, port, /* proxyInfo */ null, /* dnsRecord */ null);
+
+    transport.connectionFlags |= Ci.nsISocketTransport.ANONYMOUS_CONNECT;
+
+    const output = transport.openOutputStream(0, 0, 0) as nsIAsyncOutputStream;
+    const input = transport.openInputStream(0, 0, 0) as nsIAsyncInputStream;
+
+    return new Promise((resolve, reject) => {
+      let handler: nsITransportEventSink & nsIOutputStreamCallback & nsIInputStreamCallback = {
+        onTransportStatus(_transport, status) {
+          actor.#log.debug("transport status", status);
+          if (status === Ci.nsISocketTransport.STATUS_CONNECTED_TO) {
+            actor.#log.info("connected to", uri.spec);
+            output.asyncWait(handler, 0, 0, Services.tm.currentThread);
+          }
+        },
+
+        onOutputStreamReady() {
+          actor.#log.debug("onOutputStreamReady");
+
+          try {
+            const request = `${url}\r\n`;
+            output.write(request, request.length);
+
+            input.asyncWait(handler, 0, 0, Services.tm.currentThread);
+          } catch (err) {
+            reject(err);
+            throw err;
+          }
+        },
+
+        async onInputStreamReady(stream: nsIInputStream) {
+          actor.#log.debug("onInputStreamReady");
+
+          try {
+            const error = await Promise.resolve().then(() => {
+              // check if we can read the input stream to identify any potential certificate errors
+              input.available();
+              return null;
+            }).catch((err: { result: number }) => err);
+
+            if (is_self_signed_cert_error(error?.result)) {
+              if (from_retry) {
+                // should in theory be impossible as we add an override
+                reject(error);
+                return;
+              }
+
+              actor.#log.info("adding cert override for", uri.spec);
+
+              const security = await transport.tlsSocketControl.asyncGetSecurityInfo();
+              const certs = Cc["@mozilla.org/security/certoverride;1"]!.getService(Ci.nsICertOverrideService);
+              certs.rememberValidityOverride(
+                hostname,
+                port,
+                /* origin attributes */ {},
+                security.serverCert,
+                /* temporary */ true,
+              );
+
+              await actor.#connect_to_uri(uri, true).then(resolve).catch(reject);
+              return;
+            } else if (error != null) {
+              actor.#log.debug("unexpected error", error);
+              reject(error);
+            } else {
+              resolve(stream);
+            }
+          } catch (err) {
+            reject(err);
+            throw err;
+          }
+        },
+      };
+
+      transport.setEventSink(handler, Services.tm.currentThread);
+    });
+  }
+
+  async #prompt_experimental() {
+    const ps = Services.prompt;
+    const window = Services.wm.getMostRecentWindow("navigator:browser")! as typeof globalThis;
+
+    // dprint-ignore
+    const flags = ps.BUTTON_POS_0! * ps.BUTTON_TITLE_IS_STRING!
+                + ps.BUTTON_POS_1! * ps.BUTTON_TITLE_CANCEL!
+                + ps.BUTTON_POS_2! * ps.BUTTON_TITLE_IS_STRING!;
+
+    const result = await ps.asyncConfirmEx(
+      window.browsingContext,
+      Ci.nsIPromptService.MODAL_TYPE_TAB,
+      "Experimental Gemini Support",
+      "Support for the gemini:// protocol is experimental.\n\nWould you like to continue?",
+      flags,
+      "Continue",
+      "",
+      "Learn more",
+      "",
+      false,
+    );
+    const button = result.get("buttonNumClicked");
+
+    if (button === 0) {
+      Services.prefs.setBoolPref(NOTIFIED_EXPERIMENTAL_PREF, true);
+      return;
+    }
+
+    if (button === 2) {
+      window.gBrowser.addTrustedTab("https://glide-browser.app/gemini", { inBackground: false });
+      throw new Error("Gemini support docs were opened, reload the tab if you want to continue loading.");
+    }
+
+    throw new Error("Gemini protocol request was cancelled");
+  }
+}
+
+function is_self_signed_cert_error(error: number | null | undefined): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  const service = Cc["@mozilla.org/nss_errors_service;1"]!.getService(Ci.nsINSSErrorsService);
+  const MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT = Ci.nsINSSErrorsService.MOZILLA_PKIX_ERROR_BASE + 14;
+  return service.getXPCOMFromNSSError(MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT) === error;
+}

--- a/src/glide/browser/base/content/docs.mts
+++ b/src/glide/browser/base/content/docs.mts
@@ -30,7 +30,16 @@ interface SidebarEntry {
   target?: string;
 }
 
-const IGNORE_CODE_LANGS = new Set(["glide", "about", "file", "stderr", "auto_activate", "action", "bootstrap"]);
+const IGNORE_CODE_LANGS = new Set([
+  "glide",
+  "about",
+  "file",
+  "stderr",
+  "auto_activate",
+  "action",
+  "bootstrap",
+  "gemini",
+]);
 
 // GitHub-style admonition types
 const ADMONITION_TYPES = new Set([
@@ -56,6 +65,7 @@ const SIDEBAR: SidebarEntry[] = [
   { name: "FAQ", href: "faq.html" },
   { name: "Cookbook", href: "cookbook.html" },
   { name: "Security", href: "security.html" },
+  { name: "Gemini", href: "gemini.html" },
   { name: "Privacy", href: "privacy.html" },
   { name: "Changelog", href: "changelog.html" },
   { name: "Contributing", href: "contributing.html" },

--- a/src/glide/browser/base/content/utils/strings.mts
+++ b/src/glide/browser/base/content/utils/strings.mts
@@ -19,6 +19,28 @@ export function reverse_indexof(
   return -1;
 }
 
+/**
+ * Split the string at the first occurrence of `separator`, and return a 2-tuple containing the part before the separator, and the part after the separator.
+ *
+ * If the separator is not found, return a 2-tuple containing the string itself, followed by an empty string.
+ *
+ * For example:
+ * ```typescript
+ * partition("foo\r\nbar", "\r\n") === ["foo", "bar"];
+ * partition("foo", "bar") === ["foo", ""];
+ * ```
+ */
+export function partition(str: string, separator: string): [left: string, right: string] {
+  const sep_index = str.indexOf(separator);
+  if (sep_index === -1) {
+    return [str, ""];
+  }
+
+  const left = str.slice(0, sep_index);
+  const right = str.slice(sep_index + separator.length);
+  return [left, right];
+}
+
 interface Candidate {
   code: string;
   branch: string; // the initial character that identifies the branch

--- a/src/glide/browser/base/jar.mn
+++ b/src/glide/browser/base/jar.mn
@@ -61,3 +61,4 @@ glide.jar:
   content/bundled/markdoc.mjs                  (../../bundled/markdoc.mjs)
   content/bundled/shiki.mjs                    (../../bundled/shiki.mjs)
   content/bundled/ts-blank-space.mjs           (../../bundled/ts-blank-space.mjs)
+  content/bundled/dioscuri.mjs                 (../../bundled/dioscuri.mjs)

--- a/src/glide/docs/firefox.md
+++ b/src/glide/docs/firefox.md
@@ -10,6 +10,7 @@ Glide extends and heavily builds on top of Firefox but for the most part Glide i
 6. Updates are not automatically installed, when new versions are available - you will be _prompted_ to install them
 7. Taskbar [badges](https://connect.mozilla.org/t5/ideas/disable-profile-badge/idc-p/101744) are disabled by default, you can re-enable them with the `path:glide.firefox.taskbar.badge.enabled` pref.
 8. On Linux, the auto updater is disabled.
+9. Support for the `gemini://` [protocol](gemini.md) is included out of the box
 
 Additionally, the extension native messaging runtime paths are different:
 

--- a/src/glide/docs/gemini.md
+++ b/src/glide/docs/gemini.md
@@ -1,0 +1,23 @@
+# Gemini
+
+Glide has experimental support for the `bash:gemini://` [protocol](https://geminiprotocol.net/). A lightweight, document oriented protocol.
+
+## Unsupported features
+
+Not all features of the gemini protocol are supported yet:
+
+- [Redirects](https://geminiprotocol.net/docs/protocol-specification.gmi#redirection)
+- [User input](https://geminiprotocol.net/docs/protocol-specification.gmi#input-expected)
+- [Authentication](https://geminiprotocol.net/docs/protocol-specification.gmi#client-certificates)
+
+## Security
+
+The gemini protocol specification [recommends](https://geminiprotocol.net/docs/protocol-specification.gmi#tls-server-certificate-validation) validating TLS certificates using a TOFU system. However Glide currently just treats all self-signed certificates as valid for the gemini protocol, and does not prompt or warn about certificate changes.
+
+Additionally, Glide treats self-signed certificates as valid by adding temporary overrides to Firefox's certificate validation system.
+For this reason we only support connecting through `bash:gemini://` for the default port, `1965`, so that we cannot potentially add overrides for ports that would normally be used for HTTPS connections.
+The temporary overrides are cleared when the browser restarts.
+
+We will improve this in the future.
+
+If these security tradeoffs are undesirable, you can disable support for `bash:gemini://` by setting the `bash:glide.gemini.enabled` pref to `false`.

--- a/src/glide/generated/@types/generated/lib.gecko.xpcom.d.ts
+++ b/src/glide/generated/@types/generated/lib.gecko.xpcom.d.ts
@@ -7286,7 +7286,7 @@ type nsISTSShutdownObserver = Callable<{
 }>
 
 interface nsISocketTransportService extends nsISupports {
-  createTransport(aSocketTypes: string[], aHost: string, aPort: i32, aProxyInfo: nsIProxyInfo, dnsRecord: nsIDNSRecord): nsISocketTransport;
+  createTransport(aSocketTypes: string[], aHost: string, aPort: i32, aProxyInfo: nsIProxyInfo | null, dnsRecord: nsIDNSRecord | null): nsISocketTransport;
   createUnixDomainTransport(aPath: nsIFile): nsISocketTransport;
   createUnixDomainAbstractAddressTransport(aName: string): nsISocketTransport;
 }

--- a/src/modules/libpref/init/StaticPrefList-yaml.patch
+++ b/src/modules/libpref/init/StaticPrefList-yaml.patch
@@ -1,8 +1,8 @@
 diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
-index a6c49438aaf3464e70bf9c75c2849a6062bd096a..c3876e665fdf048360b1c6ab45288ec61f850b59 100644
+index 224524c8ff2cf5a2c53dd7a894c596d75d13baac..b36aac44b1316cfee287f2e66ec5f14d96c9f907 100644
 --- a/modules/libpref/init/StaticPrefList.yaml
 +++ b/modules/libpref/init/StaticPrefList.yaml
-@@ -8086,6 +8086,35 @@
+@@ -8524,6 +8524,40 @@
    value: 0
    mirror: always
  
@@ -32,6 +32,11 @@ index a6c49438aaf3464e70bf9c75c2849a6062bd096a..c3876e665fdf048360b1c6ab45288ec6
 +- name: glide.firefox.taskbar.badge.enabled
 +  type: bool
 +  value: false
++  mirror: always
++
++- name: glide.gemini.enabled
++  type: bool
++  value: true
 +  mirror: always
 +
 +# glide-injection-end

--- a/src/modules/libpref/init/all-js.patch
+++ b/src/modules/libpref/init/all-js.patch
@@ -1,5 +1,5 @@
 diff --git a/modules/libpref/init/all.js b/modules/libpref/init/all.js
-index e0b2092b7a9271cdf3ed863a0f5b991bb19cfe76..9eae60dfa7ad3f931d9e585a6c2067b586dabc1a 100644
+index e0b2092b7a9271cdf3ed863a0f5b991bb19cfe76..d2dc024b0faa4cb7654aab3ece514d030c47b150 100644
 --- a/modules/libpref/init/all.js
 +++ b/modules/libpref/init/all.js
 @@ -3484,7 +3484,7 @@ pref("browser.search.removeEngineInfobar.enabled", true);
@@ -11,7 +11,7 @@ index e0b2092b7a9271cdf3ed863a0f5b991bb19cfe76..9eae60dfa7ad3f931d9e585a6c2067b5
  
  // Whether or not to perform reader mode article parsing on page load.
  // If this pref is disabled, we will never show a reader mode icon in the toolbar.
-@@ -4050,6 +4050,14 @@ pref("toolkit.osKeyStore.loglevel", "Warn");
+@@ -4050,6 +4050,15 @@ pref("toolkit.osKeyStore.loglevel", "Warn");
  
  pref("extensions.formautofill.supportRTL", false);
  
@@ -20,6 +20,7 @@ index e0b2092b7a9271cdf3ed863a0f5b991bb19cfe76..9eae60dfa7ad3f931d9e585a6c2067b5
 +// Glide loggers
 +
 +pref("glide.logging.loglevel", "Error");
++pref("glide.gemini.loglevel", "Error");
 +
 +// ----- glide-injection-end -----
 +

--- a/src/netwerk/base/NetUtil-sys-mjs.patch
+++ b/src/netwerk/base/NetUtil-sys-mjs.patch
@@ -1,5 +1,5 @@
 diff --git a/netwerk/base/NetUtil.sys.mjs b/netwerk/base/NetUtil.sys.mjs
-index b767131ea23c06be1bbeefd8cec4f1e13bca5c26..09772d18837c1cc23e506c643adcc799030cc2e5 100644
+index b767131ea23c06be1bbeefd8cec4f1e13bca5c26..eb8c4ea0b4927ab2c8485931b50a1a6e6290f00a 100644
 --- a/netwerk/base/NetUtil.sys.mjs
 +++ b/netwerk/base/NetUtil.sys.mjs
 @@ -83,7 +83,7 @@ export var NetUtil = {
@@ -11,3 +11,12 @@ index b767131ea23c06be1bbeefd8cec4f1e13bca5c26..09772d18837c1cc23e506c643adcc799
     *        This argument can be one of the following:
     *         - An options object that will be passed to NetUtil.newChannel.
     *         - An existing nsIChannel.
+@@ -197,7 +197,7 @@ export var NetUtil = {
+    *        Note that this cannot be an nsIFile if you have to specify a
+    *        non-default charset or base URI.  Call NetUtil.newURI first if
+    *        you need to construct an URI using those options.
+-   * @param {Node} aWhatToLoad.loadingNode
++   * @param {Node} [aWhatToLoad.loadingNode]
+    * @param {nsIPrincipal} aWhatToLoad.loadingPrincipal
+    * @param {nsIPrincipal} aWhatToLoad.triggeringPrincipal
+    * @param {number} [aWhatToLoad.securityFlags]

--- a/src/tools/@types/generated/lib-gecko-xpcom-d-ts.patch
+++ b/src/tools/@types/generated/lib-gecko-xpcom-d-ts.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/@types/generated/lib.gecko.xpcom.d.ts b/tools/@types/generated/lib.gecko.xpcom.d.ts
+index 1b06688914abdb3a3cf827df0ff6d608e9589ef2..2cadf116bcba69114bfcdb31739846f216ac257f 100644
+--- a/tools/@types/generated/lib.gecko.xpcom.d.ts
++++ b/tools/@types/generated/lib.gecko.xpcom.d.ts
+@@ -7286,7 +7286,7 @@ type nsISTSShutdownObserver = Callable<{
+ }>
+ 
+ interface nsISocketTransportService extends nsISupports {
+-  createTransport(aSocketTypes: string[], aHost: string, aPort: i32, aProxyInfo: nsIProxyInfo, dnsRecord: nsIDNSRecord): nsISocketTransport;
++  createTransport(aSocketTypes: string[], aHost: string, aPort: i32, aProxyInfo: nsIProxyInfo | null, dnsRecord: nsIDNSRecord | null): nsISocketTransport;
+   createUnixDomainTransport(aPath: nsIFile): nsISocketTransport;
+   createUnixDomainAbstractAddressTransport(aName: string): nsISocketTransport;
+ }


### PR DESCRIPTION
This PR adds support for the `gemini://` protocol! https://geminiprotocol.net/

TODOs:
- [x] handle other protocol response types
- [x] restrict certificate exemptions to 1965
- [x] is the html rendering injection possible? do we care?
- [x] are the pipe args correct
- [x] check protocol flags
- [x] add tests
- [x] test security things (html injection)
- [x] is protocol error handling correct?
- [x] docs


follow ons (file issues):
- [x] custom css support
- [ ] don't hardcode content type and charset
- [x] file issue for redirects
- [x] file issue for user input
- [ ] file issue for authentication