### PR TITLE
test(marionette): add test for ETP preference persistance across restart

### DIFF
--- a/src/browser/components/protections/moz.build.patch
+++ b/src/browser/components/protections/moz.build.patch
@@ -1,0 +1,13 @@
+diff --git a/browser/components/protections/moz.build b/browser/components/protections/moz.build
+index 0989e17e3e..04747747ab 100644
+--- a/browser/components/protections/moz.build
++++ b/browser/components/protections/moz.build
+@@ -2,6 +2,8 @@
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
++MARIONETTE_MANIFESTS += ["test/marionette/manifest.toml"]
++
+ BROWSER_CHROME_MANIFESTS += ["test/browser/browser.toml"]
+ 
+ XPCSHELL_TESTS_MANIFESTS += ["test/xpcshell/xpcshell.toml"]

--- a/src/browser/components/protections/test/marionette/manifest.toml.patch
+++ b/src/browser/components/protections/test/marionette/manifest.toml.patch
@@ -1,0 +1,11 @@
+diff --git a/browser/components/protections/test/marionette/manifest.toml b/browser/components/protections/test/marionette/manifest.toml
+new file mode 100644
+index 0000000000..f1444056cb
+--- /dev/null
++++ b/browser/components/protections/test/marionette/manifest.toml
+@@ -0,0 +1,5 @@
++[DEFAULT]
++subsuite = "integration"
++tags = "local os_integration"
++
++["test_persist_tracking_protection.py"]

--- a/src/browser/components/protections/test/marionette/test_persist_tracking_protection.py
+++ b/src/browser/components/protections/test/marionette/test_persist_tracking_protection.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from marionette_driver import By, Wait
+from marionette_harness import MarionetteTestCase
+
+
+ABOUT_PREFERENCES_PRIVACY = "about:preferences#privacy"
+CAT_PREF = "browser.contentblocking.category"
+
+
+class TestPersistTrackingProtection(MarionetteTestCase):
+    def setUp(self):
+        super().setUp()
+        self._open_privacy_pane()
+        self._set_category_via_ui("standard")
+
+    def tearDown(self):
+        try:
+            self._open_privacy_pane()
+            self._set_category_via_ui("standard")
+        finally:
+            super().tearDown()
+
+    def _open_privacy_pane(self):
+        self.marionette.navigate(ABOUT_PREFERENCES_PRIVACY)
+        Wait(self.marionette, timeout=30).until(
+            lambda m: m.find_element(By.ID, "standardRadio")
+            and m.find_element(By.ID, "strictRadio"),
+            message="Waiting for ETP category radios on about:preferences#privacy",
+        )
+
+    def _click_and_wait_pref(self, element_id, expected_value):
+        el = self.marionette.find_element(By.ID, element_id)
+        el.click()
+        Wait(self.marionette, timeout=30).until(
+            lambda _: self.marionette.get_pref(CAT_PREF) == expected_value,
+            message=f"Waiting for {CAT_PREF} to become {expected_value!r}",
+        )
+
+    def _radio_selected(self, element_id):
+        el = self.marionette.find_element(By.ID, element_id)
+        return self.marionette.execute_script(
+            "return arguments[0].selected === true;", script_args=[el]
+        )
+
+    def _set_category_via_ui(self, category):
+        if category not in ("standard", "strict"):
+            raise ValueError(f"Unsupported ETP category: {category}")
+
+        current = self.marionette.get_pref(CAT_PREF)
+        if current == category:
+            return
+
+        if category == "standard":
+            self._click_and_wait_pref("standardRadio", "standard")
+        else:
+            self._click_and_wait_pref("strictRadio", "strict")
+
+        Wait(self.marionette, timeout=30).until(
+            lambda _: self._radio_selected(f"{category}Radio"),
+            message=f"Waiting for {category} radio to be selected",
+        )
+
+    def test_standard_to_strict_persists_after_restart(self):
+        self._open_privacy_pane()
+
+        self._set_category_via_ui("strict")
+        self.assertEqual(self.marionette.get_pref(CAT_PREF), "strict")
+        self.assertTrue(self._radio_selected("strictRadio"))
+
+        self.marionette.restart(in_app=True)
+
+        self._open_privacy_pane()
+        self.assertEqual(self.marionette.get_pref(CAT_PREF), "strict")
+        self.assertTrue(self._radio_selected("strictRadio"))
+        self.assertFalse(self._radio_selected("standardRadio"))

--- a/src/testing/marionette/harness/marionette_harness/tests/integration-tests.toml.patch
+++ b/src/testing/marionette/harness/marionette_harness/tests/integration-tests.toml.patch
@@ -1,0 +1,13 @@
+diff --git a/testing/marionette/harness/marionette_harness/tests/integration-tests.toml b/testing/marionette/harness/marionette_harness/tests/integration-tests.toml
+index 888c015066..71b8cf07fa 100644
+--- a/testing/marionette/harness/marionette_harness/tests/integration-tests.toml
++++ b/testing/marionette/harness/marionette_harness/tests/integration-tests.toml
+@@ -30,6 +30,8 @@
+ 
+ ["include:../../../../../browser/extensions/webcompat/tests/marionette/manifest.toml"]
+ 
++["include:../../../../../browser/components/protections/test/marionette/manifest.toml"]
++
+ # DOM tests
+ 
+ ["include:../../../../../dom/cache/test/marionette/manifest.toml"]


### PR DESCRIPTION
Adds a `marionette test` to verify that the enhanced tracking protection preference persists across restarts.

Run test using:

```bash
mach test browser/components/protections/test/marionette/test_persist_tracking_protection.py
```

Ref #292 