### PR TITLE
fix(excmds): `tab_pin_toggle` fallthrough into `tab_reopen`

### DIFF
--- a/src/glide/browser/base/content/browser-excmds.mts
+++ b/src/glide/browser/base/content/browser-excmds.mts
@@ -354,6 +354,7 @@ class GlideExcmdsClass {
         } else {
           gBrowser.pinTab(tab);
         }
+        break;
       }
 
       case "tab_reopen": {

--- a/src/glide/browser/base/content/test/excmds/browser_excmds.ts
+++ b/src/glide/browser/base/content/test/excmds/browser_excmds.ts
@@ -314,26 +314,25 @@ add_task(async function test_tab_pin_toggle_excmd() {
   await reload_config(function _() {});
 
   using tab = await GlideTestUtils.new_tab(KEY_TEST_FILE + "?i=1");
+  const initial_tab_count = gBrowser.tabs.length;
   is(gBrowser.selectedTab, tab);
   is(gBrowser.selectedTab.pinned, false, "Current tab should not be pinned initially");
 
   await keys(":tab_pin_toggle<CR>");
-  if (gBrowser.selectedTab !== tab) {
-    // idk man, Firefox seems to create an extra tab based off of the *other* tab that is active?
-    gBrowser.removeTab(gBrowser.selectedTab);
-    gBrowser.removeTab(gBrowser.selectedTab);
-  }
 
+  is(gBrowser.tabs.length, initial_tab_count, "Tab count should remain the same");
   is(gBrowser.selectedTab.pinned, true, "Current tab should be pinned after :tab_pin_toggle");
 
   await keys(":tab_pin_toggle<CR>");
   is(gBrowser.selectedTab.pinned, false, "Current tab should be unpinned after :tab_pin_toggle");
+  is(gBrowser.tabs.length, initial_tab_count, "Tab count should remain the same");
 });
 
 add_task(async function test_tab_pin_toggle_keymap() {
   await reload_config(function _() {});
 
   using tab = await GlideTestUtils.new_tab(KEY_TEST_FILE + "?i=1");
+  const initial_tab_count = gBrowser.tabs.length;
   is(gBrowser.selectedTab, tab);
   is(gBrowser.selectedTab.pinned, false, "Current tab should not be pinned initially");
 
@@ -341,16 +340,13 @@ add_task(async function test_tab_pin_toggle_keymap() {
   await wait_for_mode("normal");
 
   await keys("<A-p>");
-  if (gBrowser.selectedTab !== tab) {
-    // idk man, Firefox seems to create an extra tab based off of the *other* tab that is active?
-    gBrowser.removeTab(gBrowser.selectedTab);
-    gBrowser.removeTab(gBrowser.selectedTab);
-  }
+  is(gBrowser.tabs.length, initial_tab_count, "Tab count should remain the same");
 
   await waiter(() => gBrowser.selectedTab.pinned).is(true, "Tab should be pinned after <A-p>");
 
   await keys("<A-p>");
   await waiter(() => gBrowser.selectedTab.pinned).is(false, "Tab should be unpinned after <A-p>");
+  is(gBrowser.tabs.length, initial_tab_count, "Tab count should remain the same");
 });
 
 add_task(async function test_tab_reopen() {


### PR DESCRIPTION
- Adds a missing `break` in `tab_pin_toggle excmd`, so it no longer falls through to `tab_reopen`
- Updated tests to make sure tab count stays unchanged

Ref #304 

