### PR TITLE
feat: Proof-of-concept for loading config as ES modules

### DIFF
--- a/src/browser/components/gemini/GeminiProtocolHandler.sys.mts
+++ b/src/browser/components/gemini/GeminiProtocolHandler.sys.mts
@@ -5,13 +5,12 @@
 import type { GeminiProtocolChild } from "../../../glide/browser/actors/GeminiProtocolParent.sys.mjs";
 
 const Strings = ChromeUtils.importESModule("chrome://glide/content/utils/strings.mjs");
-const { buffer: gemtext_to_html } = ChromeUtils.importESModule("chrome://glide/content/bundled/dioscuri.mjs");
 
 export class GeminiProtocolHandler implements nsIProtocolHandler {
   /**
    * The protocol scheme handled by this handler.
    */
-  scheme = "gemini";
+  scheme = "glide";
 
   #log: ConsoleInstance = console.createInstance
     ? console.createInstance({ prefix: "GeminiProtocol", maxLogLevelPref: "glide.gemini.loglevel" })
@@ -26,8 +25,8 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
 
     // https://geminiprotocol.net/docs/protocol-specification.gmi#requests
     // "If a client is making a request with an empty path, the client SHOULD add a trailing '/' to the request"
-    if (!uri.filePath) {
-      uri = uri.mutate().setFilePath("/").finalize();
+    if (uri.host !== 'config') {
+      // throw
       this.#log.debug("adding a trailing slash:", uri.spec);
     }
 
@@ -36,7 +35,7 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
 
     stream_channel.setURI(uri);
     inner_channel.loadInfo = load_info;
-    inner_channel.contentType = "text/html";
+    inner_channel.contentType = "text/javascript"; // TODO
     inner_channel.contentCharset = "UTF-8";
     inner_channel.originalURI = uri;
 
@@ -46,82 +45,20 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
     //
     // The parent channel's data is just discarded so to avoid making two separate network requests
     // we just provide empty content in the parent process.
-    if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_DEFAULT) {
-      this.#log.debug("skipping fetch in parent process");
-      this.#write_to_channel("", stream => {
-        stream_channel.contentStream = stream;
-      });
-      return inner_channel;
-    }
+    // if (Services.appinfo.processType === Services.appinfo.PROCESS_TYPE_DEFAULT) {
+    //   this.#log.debug("skipping fetch in parent process");
+    //   this.#write_to_channel("", stream => {
+    //     stream_channel.contentStream = stream;
+    //   });
+    //   return inner_channel;
+    // }
 
     const suspended_channel = Services.io.newSuspendableChannelWrapper(inner_channel);
     suspended_channel.suspend();
 
     Promise.resolve()
       .then(() => this.#connect_and_read_stream(uri))
-      .then(({ header, data }) => {
-        const [status, meta] = Strings.partition(header, " ");
-
-        const content = ((): string => {
-          switch (status[0]) {
-            case "1": {
-              return this.#render_error_page(
-                "Input required",
-                `<p>This Gemini page requires user input, which is not supported yet.</p>`,
-              );
-            }
-            case "2": {
-              if (meta.startsWith("text/gemini")) {
-                return this.#render_gemtext(data);
-              }
-              return this.#render_error_page(
-                "Unknown mime type",
-                `<p>This page uses the MIME type <code>${escape_html(meta)}</code>, which is not supported yet.</p>`,
-              );
-            }
-            case "3": {
-              const link = escape_html(meta);
-              const rendered_link = meta.startsWith("gemini://") || meta.startsWith("https://")
-                ? `<a href="${link}">${link}</a>`
-                : `<code>${link}</code>`;
-              return this.#render_error_page(
-                "Redirect",
-                `<p>This page redirects to ${rendered_link}. Automatic redirects are not supported yet.</p>`,
-              );
-            }
-            case "4": {
-              return this.#render_error_page(
-                "Temporary failure",
-                `<p>The server encountered a temporary issue and could not fulfill the request.${
-                  meta ? ` Server message: ${escape_html(meta)}` : ""
-                }</p>`,
-              );
-            }
-            case "5": {
-              return this.#render_error_page(
-                "Permanent failure",
-                `<p>The server could not fulfill the request.${
-                  meta ? ` Server message: ${escape_html(meta)}` : ""
-                } </p>`,
-              );
-            }
-            case "6": {
-              return this.#render_error_page(
-                "Client authentication required",
-                `<p>This page requires authentication, which is not supported yet.${
-                  meta ? ` Server message: ${escape_html(meta)}` : ""
-                }</p>`,
-              );
-            }
-            default: {
-              return this.#render_error_page(
-                "Unknown response",
-                `<p>The server returned an unrecognized status code: <code>${escape_html(status)}</code></p>`,
-              );
-            }
-          }
-        })();
-
+      .then(({ content }) => {
         this.#write_to_channel(content, stream => {
           stream_channel.contentStream = stream;
           suspended_channel.resume();
@@ -129,13 +66,7 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
       })
       .catch(error => {
         this.#log.error(error);
-
-        const content = this.#render_error_page(
-          "Connection Failed",
-          `<p>Could not connect to the Gemini server at <code>${escape_html(uri.host)}</code>. ${
-            escape_html(Error.isError(error) ? error.message : String(error))
-          }</p>`,
-        );
+        const content = '// Error: ' + (Error.isError(error) ? error.message : String(error));
 
         this.#write_to_channel(content, stream => {
           stream_channel.contentStream = stream;
@@ -151,10 +82,10 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
    */
   allowPort(port: number, _scheme: string) {
     // see `src/glide/browser/actors/GeminiProtocolParent.sys.mts:#connect_to_uri` for details on connection handling.
-    return port === 1965;
+    return false;  // port === 1965;
   }
 
-  async #connect_and_read_stream(uri: nsIURI): Promise<{ header: string; data: string }> {
+  async #connect_and_read_stream(uri: nsIURI): Promise<{ content: string }> {
     const actor = this.#get_actor();
     if (!actor) {
       throw new Error("The GeminiProtocol process actor is unavailable.");
@@ -165,9 +96,7 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
       throw new Error(result.error || "Could not connect or read the server response");
     }
 
-    const [header, data] = Strings.partition(result.content, "\r\n");
-    this.#log.debug(`${uri.spec} response`, { header, data });
-    return { header, data };
+    return { content: result.content };
   }
 
   #get_actor(): GeminiProtocolChild | null {
@@ -184,35 +113,35 @@ export class GeminiProtocolHandler implements nsIProtocolHandler {
     callback(sis);
   }
 
-  #render_gemtext(gemtext: string): string {
-    return `
-      <head>
-        <style>${this.#styles()}</style>
-        <meta http-equiv="Content-Security-Policy" content="script-src 'none'">
-      </head>
-      <body><article class="gemini">
-    ` + gemtext_to_html(gemtext)
-      + `</article></body>`;
-  }
+  // #render_gemtext(gemtext: string): string {
+  //   return `
+  //     <head>
+  //       <style>${this.#styles()}</style>
+  //       <meta http-equiv="Content-Security-Policy" content="script-src 'none'">
+  //     </head>
+  //     <body><article class="gemini">
+  //   ` + gemtext_to_html(gemtext)
+  //     + `</article></body>`;
+  // }
 
-  #render_error_page(title: string, body_html: string): string {
-    return `
-      <head>
-        <style>${this.#styles()}</style>
-      </head>
-      <body class="gemini">
-        <h1>${escape_html(title)}</h1>
-        ${body_html}
-      </body>
-    `;
-  }
+  // #render_error_page(title: string, body_html: string): string {
+  //   return `
+  //     <head>
+  //       <style>${this.#styles()}</style>
+  //     </head>
+  //     <body class="gemini">
+  //       <h1>${escape_html(title)}</h1>
+  //       ${body_html}
+  //     </body>
+  //   `;
+  // }
 
-  #styles() {
-    if (Services.prefs.prefHasUserValue("glide.gemini.css")) {
-      return Services.prefs.getStringPref("glide.gemini.css");
-    }
-    return STYLES;
-  }
+  // #styles() {
+  //   if (Services.prefs.prefHasUserValue("glide.gemini.css")) {
+  //     return Services.prefs.getStringPref("glide.gemini.css");
+  //   }
+  //   return STYLES;
+  // }
 
   QueryInterface = ChromeUtils.generateQI(["nsIProtocolHandler"]);
 }

--- a/src/browser/components/gemini/components.conf
+++ b/src/browser/components/gemini/components.conf
@@ -11,12 +11,12 @@ Classes = [
         "esModule": "moz-src:///browser/components/gemini/dist/GeminiProtocolHandler.sys.mjs",
         "constructor": "GeminiProtocolHandler",
         "protocol_config": {
-            "scheme": "gemini",
+            "scheme": "glide",
             "flags": [
               "URI_STD",
               "URI_LOADABLE_BY_ANYONE",
             ],
-            "default_port": 1965,
+            "default_port": -1,
         },
     },
 ]

--- a/src/dom/security/nsContentSecurityUtils-cpp.patch
+++ b/src/dom/security/nsContentSecurityUtils-cpp.patch
@@ -1,0 +1,19 @@
+diff --git a/dom/security/nsContentSecurityUtils.cpp b/dom/security/nsContentSecurityUtils.cpp
+index 186c777f23504380f48c1fe2eff8e9393a668968..dafab5e30de34175edbb0678647b69faaadf5968 100644
+--- a/dom/security/nsContentSecurityUtils.cpp
++++ b/dom/security/nsContentSecurityUtils.cpp
+@@ -2097,10 +2097,14 @@ bool nsContentSecurityUtils::ValidateScriptFilename(JSContext* cx,
+   }
+   if (StringBeginsWith(filename, "file://"_ns)) {
+     // We will temporarily allow all file:// URIs through for now
+     return true;
+   }
++  if (StringBeginsWith(filename, "glide://"_ns)) {
++    // We will temporarily allow all glide:// URIs through for now
++    return true;
++  }
+   if (StringBeginsWith(filename, "jar:file://"_ns)) {
+     // We will temporarily allow all jar URIs through for now
+     return true;
+   }
+   if (filename.Equals("about:sync-log"_ns)) {

--- a/src/glide/browser/actors/GeminiProtocolParent.sys.mts
+++ b/src/glide/browser/actors/GeminiProtocolParent.sys.mts
@@ -5,6 +5,7 @@
 
 const { assert_never } = ChromeUtils.importESModule("chrome://glide/content/utils/guards.mjs");
 const { NetUtil } = ChromeUtils.importESModule("resource://gre/modules/NetUtil.sys.mjs");
+const TSBlank = ChromeUtils.importESModule("chrome://glide/content/bundled/ts-blank-space.mjs");
 
 export interface ChildMessages {}
 export interface ChildQueries {
@@ -49,25 +50,25 @@ export class GeminiProtocolParent extends JSProcessActorParent<ParentMessages, P
   async get_content(
     props: ChildQueries["Glide::Query::GetContent"]["props"],
   ): Promise<string> {
-    if (!Services.prefs.getBoolPref("glide.gemini.enabled", true)) {
-      throw new Error(`Gemini protocol support has been disabled`);
+    const uri = new URL(props.url);
+
+    // For nice module resolution we could probably check existence of files, like
+    // fname + `.js`, etc.
+    const relpath = uri.pathname.replace(/([.]m?)js$/, '$1ts');
+    const filepath = PathUtils.joinRelative('/Users/ianchamberlain/Documents/Development/glide/engine',  relpath.replace(/^\//, ''));
+
+    // TODO: resolve using glide config helpers, prevent directory traversal, etc
+    this.#log.info(`reading ${filepath}`);
+    let contents = await IOUtils.readUTF8(filepath);
+
+    // TODO: better heuristic for this? Or maybe use anchors or query params or smth
+    this.#log.debug(`got contents`);
+    if (!uri.pathname.endsWith('ts')) {
+      this.#log.info(`converting ts -> js`);
+      contents = TSBlank.default(contents);
     }
 
-    const uri = Services.io.newURI(props.url);
-    if (uri.scheme !== "gemini") {
-      throw new Error(`Expected scheme gemini, but got ${uri.scheme}`);
-    }
-
-    if (uri.port !== -1 && uri.port !== DEFAULT_PORT) {
-      throw new Error(`For security reasons, Gemini can only connect to port ${DEFAULT_PORT}`);
-    }
-
-    if (!Services.prefs.getBoolPref(NOTIFIED_EXPERIMENTAL_PREF, false)) {
-      await this.#prompt_experimental();
-    }
-
-    const stream = await this.#connect_to_uri(uri);
-    return await this.#read_stream(stream);
+    return contents;
   }
 
   #read_stream(stream: nsIInputStream): Promise<string> {

--- a/src/glide/browser/base/content/browser-api.mts
+++ b/src/glide/browser/base/content/browser-api.mts
@@ -875,6 +875,8 @@ export function make_glide_api(
       join(...parts) {
         return PathUtils.join(...parts);
       },
+
+      resolve: resolve_path,
     },
     fs: {
       async read(path, encoding): Promise<string> {
@@ -1314,6 +1316,10 @@ export function make_glide_api(
       async include(path) {
         await load_config_at_path({ absolute: resolve_path(path), relative: path });
       },
+
+      async module<T extends string>(path: T) {
+        return ('glide://config/' + path) as T // ?
+      }
     },
   };
 
@@ -1338,7 +1344,7 @@ export function make_glide_api(
       throw new Error("Non absolute paths can only be used when there is a config file defined.");
     }
 
-    return PathUtils.joinRelative(PathUtils.parent(config_path) ?? "/", path);
+    return PathUtils.normalize(PathUtils.joinRelative(PathUtils.parent(config_path) ?? "/", path));
   }
 
   function handle_ioutils_error(err: unknown, absolute: string): never {
@@ -1362,6 +1368,7 @@ async function load_config_at_path({ absolute, relative }: { absolute: string; r
   const config_str = await IOUtils.readUTF8(absolute);
 
   const sandbox = create_sandbox({
+    name: 'Glide Config',
     document: GlideBrowser._mirrored_document,
     window: GlideBrowser.sandbox_window,
     original_window: window,
@@ -1388,9 +1395,17 @@ async function load_config_at_path({ absolute, relative }: { absolute: string; r
     },
   });
 
+  // Create an extra "trampoline" so we can load the user config as a module;
+  // evalInSandbox loads in script mode by default but still allows us to import()
+  // modules, which in turn *will* be evaluated in module mode.
+
+  const config_path = 'glide://config/' + relative.replace(/([.]m?)ts$/, '$1js');
+  const trampoline_js = `
+    import(${JSON.stringify(config_path)})
+  `;
+
   try {
-    const config_js = TSBlank.default(config_str);
-    Cu.evalInSandbox(config_js, sandbox, null, `chrome://glide/config/${relative}`, 1, false);
+    Cu.evalInSandbox(trampoline_js, sandbox, null, `glide://config/${relative}`, 1, false);
   } catch (err) {
     GlideBrowser._log.error(err);
 

--- a/src/glide/browser/base/content/browser-constants.mts
+++ b/src/glide/browser/base/content/browser-constants.mts
@@ -5,7 +5,4 @@
 
 export const GLIDE_COMMANDLINE_INPUT_ANONID = "glide-commandline-input";
 
-// note: this URI doesn't actually exist but defining it like this
-//       means that devtools can resolve stack traces and show the
-//       config contents
-export const CONFIG_URI = "chrome://glide/config/glide.ts";
+export const CONFIG_URI = "glide://config/glide.ts";

--- a/src/glide/browser/base/content/browser.mts
+++ b/src/glide/browser/base/content/browser.mts
@@ -338,6 +338,7 @@ class GlideBrowserClass {
   #sandbox: Sandbox | null = null;
   get config_sandbox() {
     this.#sandbox ??= create_sandbox({
+      name: 'Glide Config',
       window: this.sandbox_window,
       original_window: window,
       document: this._mirrored_document,
@@ -538,9 +539,17 @@ class GlideBrowserClass {
     this._log.info(`Executing config file at \`${config_path}\``);
     const config_str = await IOUtils.readUTF8(config_path);
 
+    // Create an extra "trampoline" so we can load the user config as a module;
+    // evalInSandbox loads in script mode by default but still allows us to import()
+    // modules, which in turn *will* be evaluated in module mode.
+
+    const config_js_path = CONFIG_URI.replace(/([.]m?)ts$/, '$1js');
+    const trampoline_js = `
+      import(${JSON.stringify(config_js_path)})
+    `;
+
     try {
-      const config_js = TSBlank.default(config_str);
-      Cu.evalInSandbox(config_js, sandbox, null, CONFIG_URI, 1, false);
+      Cu.evalInSandbox(trampoline_js, sandbox, null, CONFIG_URI, 1, false);
     } catch (err) {
       this._log.error(err);
 

--- a/src/glide/browser/base/content/glide.d.ts
+++ b/src/glide/browser/base/content/glide.d.ts
@@ -966,6 +966,13 @@ declare global {
        */
       /// @docs-skip
       include(path: string): Promise<void>;
+
+      /**
+       * Returns an import URI for the given filepath.
+       *
+       * @example await import(await glide.module('./test.ts'))
+       */
+      module<T extends string>(path: T): Promise<T>;
     };
 
     path: {
@@ -980,6 +987,11 @@ declare global {
        * Throws an error on non-relative paths.
        */
       join(...parts: string[]): string;
+
+      /**
+       * Resolves the given path relative to the file it's called from.
+       */
+      resolve(path: string): string;
     };
 
     fs: {

--- a/src/glide/browser/base/content/sandbox.mts
+++ b/src/glide/browser/base/content/sandbox.mts
@@ -24,6 +24,7 @@ const Dedent = ChromeUtils.importESModule("chrome://glide/content/utils/dedent.m
 const DOMUtils = ChromeUtils.importESModule("chrome://glide/content/utils/dom.mjs");
 const { AssertionError } = ChromeUtils.importESModule("chrome://glide/content/utils/guards.mjs");
 const { is_empty } = ChromeUtils.importESModule("chrome://glide/content/utils/objects.mjs");
+const TSBlank = ChromeUtils.importESModule("chrome://glide/content/bundled/ts-blank-space.mjs");
 
 // note: do ***not*** add an entry to this Set without first checking if the API can be used to
 //       access the bound window, if this is the case then you *cannot* add it here.
@@ -74,6 +75,7 @@ interface SandboxProps {
   original_window: Window | null;
   browser: typeof browser | null;
   glide: typeof glide | null;
+  name?: string,
 }
 
 /**
@@ -105,12 +107,12 @@ export function create_sandbox(props: SandboxProps): Sandbox {
 
   // options pass here correspond to:
   // https://github.com/mozilla-firefox/firefox/blob/0f7aa808c07a1644fb2b386113aa3a2b31befe24/js/xpconnect/idl/xpccomponents.idl#L151
-  let proto: any = {
-    console: props.console,
-    document: props.document,
-    window: props.window,
+  const proto: any = props.window;
+  Object.assign(proto, {
+    // console: props.console,
+    // document: props.document, // hmm needed?
     glide: props.glide,
-
+    sandboxName: props.name,
     dedent: Dedent.dedent,
     css: Dedent.make_dedent_no_args("css"),
     html: Dedent.make_dedent_no_args("html"),
@@ -145,7 +147,7 @@ export function create_sandbox(props: SandboxProps): Sandbox {
       }
       throw new Error(detail ?? `assert_never: impossible to call: ${JSON.stringify(x)}`);
     },
-  };
+  });
 
   if (props.browser) {
     proto.browser = props.browser;
@@ -184,12 +186,17 @@ export function create_sandbox(props: SandboxProps): Sandbox {
     }
   }
 
-  return Cu.Sandbox(Cu.getGlobalForObject({}), {
+  const sb = Cu.Sandbox(Cu.getGlobalForObject({}), {
     // remove `Cu`, etc
     wantComponents: false,
-    sandboxPrototype: proto,
+    sandboxName: `Glide Config`, // or whatever, this might not always be config related?
+    sandboxPrototype: props.window,
+    sameZoneAs: props.window,
     freezeBuiltins: false,
+    isWebExtensionContentScript: true, // enables dynamic import
   }) as any;
+
+  return sb
 }
 
 export class FileNotFoundError extends Error {


### PR DESCRIPTION
Note: this is absolutely a proof-of-concept, there may be security issues and nice error handling is definitely lacking, but I wanted to be able to use modules for config so I spent some time trying to figure out how to implement it and this is the result.

I'm leaving this as a draft to see if this direction seems worth pursuing; I am not a browser expert so I'm not sure if there might be security implications (scary!) of doing something like this or any other issues, before I spend more time cleaning up the implementation.

The basic idea how this works:
- Register a `glide://` protocol handler, which serves TSBlank'd files relative to the resolved top-level `glide.ts` config
- In the config sandbox evaluation, run `import("glide://config/glide.ts")` instead of evaluating the file contents directly
- Now the top-level config is evaluated in module mode, which allows for static `import` via relative paths and such

A nice side effect is that you can look at the "effective configuration" by loading up `glide://config/glide.js` (or `.js`) in the browser, and load errors in `:repl` can be clicked to lead directly to the source of the error (even for imported modules).

To build this, I am utilizing the existing `gemini://` protocol handler since it already implemented a lot of boilerplate, but things seems to "basically work" using these changes. Things I'd want to do to properly upstream:
- [ ] Separate `glide://` protocol handler, obviously don't want to actually replace the `gemini://` protocol with this
- [ ] Better error handling / reporting; if the `glide://` handler can't resolve a file or something that should be surfaced to the user instead of just serving an error message
- [ ] Module resolution: it would be nice to `import from './test'` instead of requiring `.js`. Maybe it's possible to make the `view-source:glide://config/...` lead to the original TypeScript source, while `glide://config/...` contains JS?
- [ ] Double-check that the sandbox changes I made are both necessary for this to work, and don't regress any other functionality. As far as I can tell the browser APIs and everything are still functional, but the sandbox is used in a handful of places so it's possible something breaks with this. 
- [ ] Put this functionality behind an `about:config` flag maybe? Similar to `glide.gemini.enabled` this seems like it could break people's config so it might be best to make it experimental 

Example file setup to test it out:
```console
$ cat engine/glide.ts engine/test.ts engine/test2.ts
───────────────────────────────────────────────────────────────────────────────────────────
File: engine/glide.ts
───────────────────────────────────────────────────────────────────────────────────────────
/// <reference path="./glide.d.ts" />

import { get_it, HI } from './test.js';
const foo: string = '123';
get_it();
console.log(HI, foo);
───────────────────────────────────────────────────────────────────────────────────────────
───────────────────────────────────────────────────────────────────────────────────────────
File: engine/test.ts
───────────────────────────────────────────────────────────────────────────────────────────
import { print } from './test2.js';

export const HI: string = 'hello world'

export function get_it() {
  print(HI);
  return HI
}
───────────────────────────────────────────────────────────────────────────────────────────
───────────────────────────────────────────────────────────────────────────────────────────
File: engine/test2.ts
───────────────────────────────────────────────────────────────────────────────────────────
export function print(...args: any[]) {
  console.log(...args)
}
───────────────────────────────────────────────────────────────────────────────────────────
```


