### PR TITLE
ci: try using depot ci for lint

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    name: lint
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Configure git
+        run: |
+          git config --global \
+            url."https://github.com/mozilla-firefox/firefox.git".insteadOf \
+            "git@github.com:mozilla-firefox/firefox.git"
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download Firefox source
+        run: |
+          pnpm firefox:download
+
+      - name: Bootstrap repo
+        run: |
+          pnpm bootstrap
+
+      - name: Run lint
+        run: |
+          pnpm lint


### PR DESCRIPTION
notes:
- this doesn't delete the existing `lint` workflow, we still need it to pass status checks
- we can't use depot CI for everything yet as they only support linux x86 right now :/ but I'm motivated to use it just for `lint` in particular as we should be able to make it significantly faster than the github workflow