### PR TITLE
ci: use snapshot images for faster lint runs

### DIFF
--- a/.depot/workflows/build-image.yml
+++ b/.depot/workflows/build-image.yml
@@ -1,0 +1,22 @@
+name: Build CI image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    runs-on: depot-ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Read firefox version
+        id: version
+        run: echo "version=$(jq -r .version.version firefox.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push CI image
+        uses: ./.github/actions/build-ci-image
+        with:
+          image-tag: ${{ steps.version.outputs.version }}

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -4,19 +4,59 @@ on:
   workflow_dispatch:
 
 jobs:
+  prepare:
+    name: prepare image
+    runs-on:
+      size: 2x8
+      image: 9c42191sh0.registry.depot.dev/glide-ci:latest
+    outputs:
+      image-tag: ${{ steps.check.outputs.image-tag }}
+    steps:
+      - name: Read baked firefox version
+        id: baked
+        run: |
+          if [ -f firefox.json ]; then
+            echo "version=$(jq -r .version.version firefox.json)" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          clean: false
+
+      - name: Check firefox version against baked image
+        id: check
+        run: |
+          expected=$(jq -r .version.version firefox.json)
+          actual="${{ steps.baked.outputs.version }}"
+          echo "image-tag=$expected" >> "$GITHUB_OUTPUT"
+          if [ "$expected" = "$actual" ]; then
+            echo "rebuild=false" >> "$GITHUB_OUTPUT"
+            echo "image is up-to-date for firefox $expected"
+          else
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+            echo "image firefox version '$actual' does not match firefox.json '$expected', rebuilding"
+          fi
+
+      - name: Build & push CI image
+        if: steps.check.outputs.rebuild == 'true'
+        uses: ./.github/actions/build-ci-image
+        with:
+          image-tag: ${{ steps.check.outputs.image-tag }}
+
   lint:
     name: lint
-    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    needs: prepare
+    runs-on:
+      size: 2x8
+      image: 9c42191sh0.registry.depot.dev/glide-ci:${{ needs.prepare.outputs.image-tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Configure git
-        run: |
-          git config --global \
-            url."https://github.com/mozilla-firefox/firefox.git".insteadOf \
-            "git@github.com:mozilla-firefox/firefox.git"
+          clean: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
@@ -29,14 +69,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download Firefox source
-        run: |
-          pnpm firefox:download
-
-      - name: Bootstrap repo
-        run: |
-          pnpm bootstrap
+      - name: Bootstrap
+        run: pnpm bootstrap --offline
 
       - name: Run lint
-        run: |
-          pnpm lint
+        run: pnpm lint

--- a/.github/actions/build-ci-image/action.yml
+++ b/.github/actions/build-ci-image/action.yml
@@ -1,0 +1,49 @@
+name: Build CI image
+description: >-
+  Build the ci snapshot image with the firefox source code included.
+  Assumes the repository is already checked out.
+
+inputs:
+  image-tag:
+    description: the firefox version to push
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure git
+      shell: bash
+      run: |
+        git config --global \
+          url."https://github.com/mozilla-firefox/firefox.git".insteadOf \
+          "git@github.com:mozilla-firefox/firefox.git"
+
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+    - name: Setup Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: "24"
+        cache: "pnpm"
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Download Firefox source
+      shell: bash
+      run: pnpm firefox:download
+
+    - name: Bootstrap repo
+      shell: bash
+      run: pnpm bootstrap
+
+    - name: Push snapshot (versioned)
+      uses: depot/snapshot-action@6af2bc7128223169fb12a5e1521c9576d5b7a8bf # v1.1.2
+      with:
+        image: 9c42191sh0.registry.depot.dev/glide-ci:${{ inputs.image-tag }}
+
+    - name: Push snapshot (latest)
+      uses: depot/snapshot-action@6af2bc7128223169fb12a5e1521c9576d5b7a8bf # v1.1.2
+      with:
+        image: 9c42191sh0.registry.depot.dev/glide-ci:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,17 @@ jobs:
           depot ci logs "$run_id" --job prepare --follow || true
           depot ci logs "$run_id" --job lint --follow || true
 
+          # the log-follows above can return while the run is still "running", so we
+          # need to work around that by polling until a terminal state is hit.
+          status=""
+          for _ in $(seq 1 360); do # ~30 min @ 5s, very overkill
+            status=$(depot ci status "$run_id" --output json | jq -r '.status')
+            case "$status" in
+              queued | running | pending | starting | creating) sleep 5 ;;
+              *) break ;;
+            esac
+          done
+
           # "finished" is the only success status; anything else fails the job.
-          status=$(depot ci status "$run_id" --output json | jq -r '.status')
           echo "Depot run status: $status"
           [ "$status" = "finished" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
             exit 1
           fi
 
-          depot ci logs "$run_id" --follow
+          depot ci logs "$run_id" --job prepare --follow || true
+          depot ci logs "$run_id" --job lint --follow || true
 
           # "finished" is the only success status; anything else fails the job.
           status=$(depot ci status "$run_id" --output json | jq -r '.status')


### PR DESCRIPTION
This uses Depot CI's support for custom images to preload the Firefox source code into the CI image.

The end-to-end time to run the lint CI job drops from ~3m20s to ~1m20s which is huge for iteration speed.